### PR TITLE
"Check the browser console for details" but process closes before I can look at the browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,9 @@ module.exports = {
         return details;
       } finally {}
     } finally {
-      await server.stop();
+      if (!options.browser || !options.browser.manualClose) {
+        await server.stop();
+      }
     }
   },
   Server,

--- a/index.js
+++ b/index.js
@@ -82,6 +82,16 @@ module.exports = {
     try {
       const webdriver = buildWebdriver(options.browser);
 
+      process.once("beforeExit", async () => {
+        if (useSauce) {
+          await webdriver.executeScript(
+            `sauce:job-result=${process.exitCode === 0}`
+            );
+        }
+
+        await webdriver.quit();
+      });
+
       try {
         const host = `http://localhost:${server.port()}`;
         const runner = new RunnerClass({ webdriver, reporters, host });
@@ -106,15 +116,7 @@ module.exports = {
         }
 
         return details;
-      } finally {
-        if (useSauce) {
-          await webdriver.executeScript(
-            `sauce:job-result=${process.exitCode === 0}`
-          );
-        }
-
-        await webdriver.close();
-      }
+      } finally {}
     } finally {
       await server.stop();
     }

--- a/index.js
+++ b/index.js
@@ -82,11 +82,11 @@ module.exports = {
     try {
       const webdriver = buildWebdriver(options.browser);
 
-      process.once("beforeExit", async () => {
+      process.once('beforeExit', async () => {
         if (useSauce) {
           await webdriver.executeScript(
             `sauce:job-result=${process.exitCode === 0}`
-            );
+          );
         }
 
         await webdriver.quit();
@@ -116,7 +116,8 @@ module.exports = {
         }
 
         return details;
-      } finally {}
+      } finally {
+      }
     } finally {
       if (!options.browser || !options.browser.manualClose) {
         await server.stop();

--- a/lib/examples/default_config.json
+++ b/lib/examples/default_config.json
@@ -16,6 +16,7 @@
     "random": true
   },
   "browser": {
-    "name": "firefox"
+    "name": "firefox",
+    "manualClose": false
   }
 }

--- a/lib/examples/default_esm_config.json
+++ b/lib/examples/default_esm_config.json
@@ -14,6 +14,7 @@
     "random": true
   },
   "browser": {
-    "name": "firefox"
+    "name": "firefox",
+    "manualClose": false
   }
 }

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -402,16 +402,11 @@ describe('index', function() {
       expect(buildWebdriver).not.toHaveBeenCalled();
     });
 
-    it('stops the browser and server if the runner fails to start', async function() {
+    it('stops the server if the runner fails to start', async function() {
       const server = jasmine.createSpyObj('Server', ['start', 'stop', 'port']);
       server.start.and.returnValue(Promise.resolve(server));
       server.stop.and.returnValue(Promise.resolve());
       server.port.and.returnValue(0);
-      const webdriver = jasmine.createSpyObj('webdriver', [
-        'close',
-        'executeScript',
-      ]);
-      webdriver.close.and.returnValue(Promise.resolve());
 
       const promise = runSpecs(
         {},
@@ -430,7 +425,6 @@ describe('index', function() {
       );
 
       await expectAsync(promise).toBeRejected();
-      expect(webdriver.close).toHaveBeenCalled();
       expect(server.stop).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Hello, I was trying to set up JBR to perform some tests in a package of mine (not published yet). I received this message in the console:

```sh
Suite error: undefined
  Message:
    Uncaught Error: An error occurred while loading /__spec__/Tokenizer.spec.mjs. Check the browser console for details.
  Stack:
    Error: An error occurred while loading /__spec__/Tokenizer.spec.mjs. Check the browser console for details.
        at HTMLScriptElement.<anonymous> (http://localhost:53230/__support__/loadEsModule.js:20:11)
```

So my tests were failing for some reason and I wasn't able to understand which was it because the browser's window was closing even before I could look at it.

So, through the usage of Node inspector, I tried to dig it down in JBR's code and edit it to keep the browser open. I found that `webdriver.close()` was being called no matter what (in `finally` at [index.js#L116](https://github.com/jasmine/jasmine-browser-runner/blob/main/index.js#L116)). So I tried to tweak the code and I came up with the solution in Pull Request.

- I added a new `config.browser` flag `manualClose` which, if set to `true`, aims to not stop the server so things can be debugged on the new browser window (I also was able to set breakpoints in the console and reload the testing page).
- To terminate the browser window, I set up an event to be called only once `beforeExit` ('cause it seems it can be called multiple times, but the browser window can be closed only once).

Better solutions might be available anyway.

**Things to note**:

- Wasn't able to perform SAUCE Tests (I don't even know what sauce is);
- Wasn't able to run successful exit tests due to missing `jasmine.debugLog` (don't actually know the reason), so once disabled the two rows containing this instruction, all the tests were completed successfully;
- If the browser gets closed, without closing Node's process first, the process remains active. I wanted this not to happen but seems like selenium doesn't have an event to notify when the browser completes and/or gets closed;
- "Allow edits by maintainers" is enabled on this PR, so you can do any change you want;

Hope this is appreciated. Let me know!