### PR TITLE
Added support for headless Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To use a browser other than Firefox, add a `browser` field to
 }
 ```
 
-Its value can be `"firefox"`, `"safari"`, 
+Its value can be `"firefox"`, `"headlessFirefox"`, `"safari"`, 
 `"MicrosoftEdge"`, `"chrome"`, or `"headlessChrome"`.
 
 ## ES module support

--- a/lib/types.js
+++ b/lib/types.js
@@ -116,7 +116,7 @@
  * @type boolean | undefined
  */
 /**
- * The browser name. Valid values include "firefox",
+ * The browser name. Valid values include "firefox", "headlessFirefox",
  * "safari", "MicrosoftEdge", "chrome", and "headlessChrome".
  * @name BrowserInfo#name
  * @type string | undefined

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -29,6 +29,15 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
         .forBrowser('chrome')
         .withCapabilities(caps)
         .build();
+    } else if (browserName === 'headlessFirefox') {
+      const caps = webdriver.Capabilities.firefox();
+      caps.set('moz:firefoxOptions', {
+        args: ['--headless', '--width=1024', '--height=768'],
+      });
+      return webdriverBuilder
+        .forBrowser('firefox')
+        .withCapabilities(caps)
+        .build();
     } else {
       return webdriverBuilder.forBrowser(browserName).build();
     }

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -27,6 +27,17 @@ describe('webdriver', function() {
         });
       });
 
+      it('handles headlessFirefox as a special case', function() {
+        const builder = new MockWebdriverBuilder();
+
+        buildWebdriver('headlessFirefox', builder);
+
+        expect(builder.browserName).toEqual('firefox');
+        expect(builder.capabilities.get('moz:firefoxOptions')).toEqual({
+          args: ['--headless', '--width=1024', '--height=768'],
+        });
+      });
+
       it('does not use Sauce', function() {
         const builder = new MockWebdriverBuilder();
 


### PR DESCRIPTION
- fixes #19 

I followed the existing way it is done in Chrome to add the capabilities manually rather than using `new firefox.Options().headless()` etc because there doesn't seem to be an equivalent for the Chrome options.

I note that CircleCI doesn't seem to be running specific tests against firefox (and now headlessFirefox). Should we add Firefox to the below and add a firefox browser smoke test for it perhaps?

https://github.com/jasmine/jasmine-browser-runner/blob/e688cc302d313eb4bbc0c6169de2d68efb4af8ad/.circleci/config.yml#L30-L36