### PR TITLE
Fix: Chrome headless on docker

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -23,6 +23,7 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
           '--no-sandbox',
           'window-size=1024,768',
           '--disable-gpu',
+          '--disable-dev-shm-usage', // flag needed to avoid issues within docker https://stackoverflow.com/questions/56218242/headless-chromium-on-docker-fails
         ],
       });
       return webdriverBuilder

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -23,6 +23,7 @@ describe('webdriver', function() {
             '--no-sandbox',
             'window-size=1024,768',
             '--disable-gpu',
+            '--disable-dev-shm-usage',
           ],
         });
       });


### PR DESCRIPTION
Hello, I'm migrating our jasmine integration from the legacy ruby version to the latest javascript version. Everything was working well until I moved the test suite to docker (gitlab CI), here chrome headless wasn't working:

```
root@d131d44a7f93:/app# ./node_modules/jasmine-browser-runner/bin/jasmine-browser-runner runSpecs --config=spec/javascripts/support/jasmine.json --browser=headlessChrome
Jasmine server is running here: http://localhost:42071
Jasmine tests are here:         /app/spec/javascripts
Source files are here:          /app/public/assets
Running tests in the browser...
NoSuchSessionError: invalid session id
    at Object.throwDecodedError (/app/node_modules/selenium-webdriver/lib/error.js:524:15)
    at parseHttpResponse (/app/node_modules/selenium-webdriver/lib/http.js:587:13)
    at Executor.execute (/app/node_modules/selenium-webdriver/lib/http.js:515:28)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async thenableWebDriverProxy.execute (/app/node_modules/selenium-webdriver/lib/webdriver.js:741:17)
    at async Object.runSpecs (/app/node_modules/jasmine-browser-runner/index.js:134:9)
    at async Command.runSpecs (/app/node_modules/jasmine-browser-runner/lib/command.js:187:5) {
  remoteStacktrace: '#0 0x562b164362a3 <unknown>\n' +
    '#1 0x562b161f4dfd <unknown>\n' +
    '#2 0x562b16224a05 <unknown>\n' +
    '#3 0x562b16225fde <unknown>\n' +
    '#4 0x562b1648663e <unknown>\n' +
    '#5 0x562b16489b79 <unknown>\n' +
    '#6 0x562b1646c89e <unknown>\n' +
    '#7 0x562b1648aa83 <unknown>\n' +
    '#8 0x562b1645f505 <unknown>\n' +
    '#9 0x562b164abca8 <unknown>\n' +
    '#10 0x562b164abe36 <unknown>\n' +
    '#11 0x562b164c7333 <unknown>\n' +
    '#12 0x7f4768c1a4a4 start_thread\n'
}
```

This is because `--disable-dev-shm-usage` is missing from the options sent to chrome when starting

With the proper option it works as expected:

```
root@d131d44a7f93:/app# ./node_modules/jasmine-browser-runner/bin/jasmine-browser-runner runSpecs --config=spec/javascripts/support/jasmine.json --browser=headlessChrome
Jasmine server is running here: http://localhost:39429
Jasmine tests are here:         /app/spec/javascripts
Source files are here:          /app/public/assets
Running tests in the browser...
Randomized with seed 05143
Started
...................................................................................................................................................................................................................................................................................


275 specs, 0 failures
Finished in 6.241 seconds
Randomized with seed 05143 (jasmine-browser-runner runSpecs --seed=05143)
```