### PR TITLE
support any remote selenium grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ over and `browserName` which is required by selenium. All of the values in the
 a new browser session minus the `url`.
 
 ## Saucelabs support (legacy)
-> NOTE: this may be removed in favour of using the above configuration in the future so it is advised that you migrate your configuration to use the above format instead
+> NOTE: the below configuration format only supports using Saucelabs in the US. if connecting from the EU, please use the above specifying a `url` value specific to your region (e.g. `https://ondemand.eu-central-1.saucelabs.com:443/wd/hub`) to avoid a connection error of `WebDriverError: This user is unauthorized to the region. Please try another region, or contact customer support.`
+
+> WARNING: the below configuration format may be removed in favour of using the above in the future so it is advised that you migrate to the above
 
 jasmine-browser-runner can run your Jasmine specs on [Saucelabs](https://saucelabs.com/).
 To use Saucelabs, set `browser.name`, `browser.useSauce`, and `browser.sauce`

--- a/README.md
+++ b/README.md
@@ -216,6 +216,37 @@ over and `browserName` which is required by selenium. All of the values in the
 `browser` object are passed as capabilities to the grid hub url to instantiate 
 a new browser session minus the `url`.
 
+## Saucelabs support (legacy)
+> NOTE: this may be removed in favour of using the above configuration in the future so it is advised that you migrate your configuration to use the above format instead
+
+jasmine-browser-runner can run your Jasmine specs on [Saucelabs](https://saucelabs.com/).
+To use Saucelabs, set `browser.name`, `browser.useSauce`, and `browser.sauce`
+in your config file as follows:
+
+```json
+{
+  // ...
+  "browser": {
+    "name": "safari",
+    "useSauce": true,
+    "sauce": {
+      "browserVersion": "13",
+      "os": "OS X 10.15",
+      "tags": ["your tag", "your other tag"],
+      "tunnelIdentifier": "tunnel ID",
+      "username": "your Saucelabs username",
+      "accessKey": "your Saucelabs access key"
+    }
+  }
+}
+```
+
+All properties of `browser.sauce` are optional except for `username` and 
+`accessKey`. It's best to omit `browser.sauce.os` unless you need to run on a 
+specific operating system. Setting `browser.sauce.tunnelIdentifier` is strongly
+recommended unless you're sure that your account will never have more than one
+active tunnel.
+
 ## Want more control?
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -165,33 +165,56 @@ To run the specs:
 
 ## Saucelabs support
 
-jasmine-browser-runner can run your Jasmine specs on [Saucelabs](https://saucelabs.com/).
-To use Saucelabs, set `browser.name`, `browser.useSauce`, and `browser.sauce`
+jasmine-browser-runner can run your Jasmine specs on a remote grid
+provider like [Saucelabs](https://saucelabs.com/), 
+[BrowserStack](https://browserstack.com) or your own Selenium Grid.
+To use a remote grid hub, set the `browser` object
 in your config file as follows:
 
 ```json
+// jasmine-browser.json
 {
   // ...
+  // BrowserStack
   "browser": {
-    "name": "safari",
-    "useSauce": true,
-    "sauce": {
+    "url": "https://hub-cloud.browserstack.com/wd/hub",
+    "browserName": "safari",
+    "bstack:options": {
       "browserVersion": "13",
-      "os": "OS X 10.15",
-      "tags": ["your tag", "your other tag"],
-      "tunnelIdentifier": "tunnel ID",
-      "username": "your Saucelabs username",
+      "os": "OS X",
+      "osVersion": "Snow Leopard",
+      "local": "true",
+      "localIdentifier": "tunnel ID",
+      "debug": "true",
+      "userName": "your BrowserStack username",
+      "accessKey": "your BrowserStack access key"
+    }
+  }
+}
+```
+```json
+// jasmine-browser.json
+{
+  // ...
+  // Saucelabs
+  "browser": {
+    "url": "https://ondemand.saucelabs.com/wd/hub",
+    "browserName": "safari",
+    "platformName": "macOS 12",
+    "sauce:options": {
+      "tunnel-identifier": "tunnel ID",
+      "userName": "your Saucelabs username",
       "accessKey": "your Saucelabs access key"
     }
   }
 }
 ```
 
-All properties of `browser.sauce` are optional except for `username` and 
-`accessKey`. It's best to omit `browser.sauce.os` unless you need to run on a 
-specific operating system. Setting `browser.sauce.tunnelIdentifier` is strongly
-recommended unless you're sure that your account will never have more than one
-active tunnel.
+When using a remote grid provider, all properties of the `browser` object are 
+optional except for `url` which indicates the remote grid hub URL to connect
+over and `browserName` which is required by selenium. All of the values in the 
+`browser` object are passed as capabilities to the grid hub url to instantiate 
+a new browser session minus the `url`.
 
 ## Want more control?
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To run the specs:
 2. Run `npx jasmine-browser-runner`.
 3. Visit <http://localhost:8888>.
 
-## Saucelabs support
+## Remote Grid support (Saucelabs, BrowserStack, etc.)
 
 jasmine-browser-runner can run your Jasmine specs on a remote grid
 provider like [Saucelabs](https://saucelabs.com/), 

--- a/README.md
+++ b/README.md
@@ -177,17 +177,20 @@ in your config file as follows:
   // ...
   // BrowserStack
   "browser": {
-    "url": "https://hub-cloud.browserstack.com/wd/hub",
-    "browserName": "safari",
-    "bstack:options": {
-      "browserVersion": "13",
-      "os": "OS X",
-      "osVersion": "Snow Leopard",
-      "local": "true",
-      "localIdentifier": "tunnel ID",
-      "debug": "true",
-      "userName": "your BrowserStack username",
-      "accessKey": "your BrowserStack access key"
+    "name": "safari",
+    "useRemoteSeleniumGrid": true,
+    "remoteSeleniumGrid": {
+      "url": "https://hub-cloud.browserstack.com/wd/hub",
+      "bstack:options": {
+        "browserVersion": "13",
+        "os": "OS X",
+        "osVersion": "Snow Leopard",
+        "local": "true",
+        "localIdentifier": "tunnel ID",
+        "debug": "true",
+        "userName": "your BrowserStack username",
+        "accessKey": "your BrowserStack access key"
+      }
     }
   }
 }
@@ -198,23 +201,28 @@ in your config file as follows:
   // ...
   // Saucelabs
   "browser": {
-    "url": "https://ondemand.saucelabs.com/wd/hub",
-    "browserName": "safari",
-    "platformName": "macOS 12",
-    "sauce:options": {
-      "tunnel-identifier": "tunnel ID",
-      "userName": "your Saucelabs username",
-      "accessKey": "your Saucelabs access key"
+    "name": "safari",
+    "useRemoteSeleniumGrid": true,
+    "remoteSeleniumGrid": {
+      "url": "https://ondemand.saucelabs.com/wd/hub",
+      "platformName": "macOS 12",
+      "sauce:options": {
+        "tunnel-identifier": "tunnel ID",
+        "userName": "your Saucelabs username",
+        "accessKey": "your Saucelabs access key"
+      }
     }
   }
 }
 ```
 
-When using a remote grid provider, all properties of the `browser` object are 
-optional except for `url` which indicates the remote grid hub URL to connect
-over and `browserName` which is required by selenium. All of the values in the 
-`browser` object are passed as capabilities to the grid hub url to instantiate 
-a new browser session minus the `url`.
+When using a remote grid provider, all properties of the `browser` object are
+optional except for `name` which will be passed as the `browserName` capability,
+and `useRemoteSeleniumGrid` which must be set to a value of `true`. if a
+`remoteSeleniumGrid` object is included, any values it contains, with the
+exception of the `url` will be used as `capabilties` sent to the grid hub url.
+if no value is specified for the `url` then a default of
+`http://localhost:4445/wd/hub` is used. 
 
 ## Saucelabs support (legacy)
 > NOTE: the below configuration format only supports using Saucelabs in the US. if connecting from the EU, please use the above specifying a `url` value specific to your region (e.g. `https://ondemand.eu-central-1.saucelabs.com:443/wd/hub`) to avoid a connection error of `WebDriverError: This user is unauthorized to the region. Please try another region, or contact customer support.`

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = {
     if (useSauce || useRemote) {
       if (options.port) {
         throw new Error(
-          "Can't specify a port when browser.useSauce is true or browser.useRemoteSeleniumGrid is set"
+          "Can't specify a port when browser.useSauce or browser.useRemoteSeleniumGrid is true"
         );
       }
 

--- a/index.js
+++ b/index.js
@@ -81,13 +81,13 @@ module.exports = {
 
     const reporters = await createReporters(options, deps);
     const useSauce = options.browser && options.browser.useSauce;
-    const remote = options.browser && options.browser.url;
+    const useRemote = options.browser && options.browser.useRemoteSeleniumGrid;
     let portRequest;
 
-    if (useSauce || remote) {
+    if (useSauce || useRemote) {
       if (options.port) {
         throw new Error(
-          "Can't specify a port when browser.useSauce is true or browser.url is set"
+          "Can't specify a port when browser.useSauce is true or browser.useRemoteSeleniumGrid is set"
         );
       }
 

--- a/index.js
+++ b/index.js
@@ -81,11 +81,14 @@ module.exports = {
 
     const reporters = await createReporters(options, deps);
     const useSauce = options.browser && options.browser.useSauce;
+    const remote = options.browser && options.browser.url;
     let portRequest;
 
-    if (useSauce) {
+    if (useSauce || remote) {
       if (options.port) {
-        throw new Error("Can't specify a port when browser.useSauce is true");
+        throw new Error(
+          "Can't specify a port when browser.useSauce is true or browser.url is set"
+        );
       }
 
       portRequest = 5555;

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -1,6 +1,5 @@
 function buildWebdriver(browserInfo, webdriverBuilder) {
-  const webdriver = require('selenium-webdriver'),
-    Capability = webdriver.Capability;
+  const webdriver = require('selenium-webdriver');
 
   webdriverBuilder = webdriverBuilder || new webdriver.Builder();
   const remote = typeof browserInfo === 'object' && browserInfo.url;

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -1,14 +1,15 @@
 function buildWebdriver(browserInfo, webdriverBuilder) {
-  const webdriver = require('selenium-webdriver');
+  const webdriver = require('selenium-webdriver'),
+    Capability = webdriver.Capability;
 
   webdriverBuilder = webdriverBuilder || new webdriver.Builder();
-  const remote = typeof browserInfo === 'object' && browserInfo.url;
+  const remote = typeof browserInfo === 'object' && (browserInfo.useSauce || browserInfo.url);
   let browserName;
 
   if (typeof browserInfo === 'string') {
     browserName = browserInfo;
   } else if (browserInfo) {
-    browserName = browserInfo.browserName;
+    browserName = browserInfo.name || browserInfo.browserName;
   }
 
   browserName = browserName || 'firefox';
@@ -43,9 +44,33 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
     }
   }
 
-  const url = browserInfo.url;
-  const capabilities = { ...browserInfo, browserName };
-  delete capabilities.url;
+  let url;
+  let capabilities;
+  if (browserInfo.url) {
+    url = browserInfo.url;
+    capabilities = {
+      ...browserInfo,
+      [Capability.BROWSER_NAME]: browserName,
+    };
+    delete capabilities.url;
+  } else if (browserInfo.useSauce) {
+    // handle legacy `sauce` object
+    url = `http://${sauce.username}:${sauce.accessKey}@ondemand.saucelabs.com/wd/hub`;
+    const sauce = browserInfo.sauce;
+    capabilities = {
+      [Capability.BROWSER_NAME]: browserName,
+      build: sauce.build,
+      tags: sauce.tags,
+    };
+
+    capabilities[Capability.PLATFORM_NAME] = sauce.os;
+    capabilities[Capability.BROWSER_VERSION] = sauce.browserVersion;
+    capabilities['sauce:options'] = {
+      'tunnel-identifier': sauce.tunnelIdentifier,
+    };
+  } else {
+    url = 'http://@localhost:4445/wd/hub';
+  }
 
   return webdriverBuilder
     .withCapabilities(capabilities)

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -3,18 +3,18 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
     Capability = webdriver.Capability;
 
   webdriverBuilder = webdriverBuilder || new webdriver.Builder();
-  const useSauce = typeof browserInfo === 'object' && browserInfo.useSauce;
+  const remote = typeof browserInfo === 'object' && browserInfo.url;
   let browserName;
 
   if (typeof browserInfo === 'string') {
     browserName = browserInfo;
   } else if (browserInfo) {
-    browserName = browserInfo.name;
+    browserName = browserInfo.browserName;
   }
 
   browserName = browserName || 'firefox';
 
-  if (!useSauce) {
+  if (!remote) {
     if (browserName === 'headlessChrome') {
       const caps = webdriver.Capabilities.chrome();
       caps.set('goog:chromeOptions', {
@@ -44,26 +44,13 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
     }
   }
 
-  const sauce = browserInfo.sauce;
-  const capabilities = {
-    [Capability.BROWSER_NAME]: browserName,
-    build: sauce.build,
-    tags: sauce.tags,
-  };
-
-  capabilities[Capability.PLATFORM_NAME] = sauce.os;
-  capabilities[Capability.BROWSER_VERSION] = sauce.browserVersion;
-  capabilities['sauce:options'] = {
-    'tunnel-identifier': sauce.tunnelIdentifier,
-  };
+  const url = browserInfo.url;
+  const capabilities = {...browserInfo, browserName};
+  delete capabilities.url;
 
   return webdriverBuilder
     .withCapabilities(capabilities)
-    .usingServer(
-      browserInfo.useSauce
-        ? `http://${sauce.username}:${sauce.accessKey}@ondemand.saucelabs.com/wd/hub`
-        : 'http://@localhost:4445/wd/hub'
-    )
+    .usingServer(url)
     .build();
 }
 

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -75,7 +75,9 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
         'tunnel-identifier': sauce.tunnelIdentifier,
       };
     }
-  } else {
+  }
+
+  if (!capabilities) {
     capabilities = {
       [Capability.BROWSER_NAME]: browserName,
     };

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -3,20 +3,20 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
     Capability = webdriver.Capability;
 
   webdriverBuilder = webdriverBuilder || new webdriver.Builder();
-  const remote =
-    typeof browserInfo === 'object' &&
-    (browserInfo.useSauce || browserInfo.url);
+  const useSauce = typeof browserInfo === 'object' && browserInfo.useSauce;
+  const useRemote =
+    typeof browserInfo === 'object' && browserInfo.useRemoteSeleniumGrid;
   let browserName;
 
   if (typeof browserInfo === 'string') {
     browserName = browserInfo;
   } else if (browserInfo) {
-    browserName = browserInfo.name || browserInfo.browserName;
+    browserName = browserInfo.name;
   }
 
   browserName = browserName || 'firefox';
 
-  if (!remote) {
+  if (!(useRemote || useSauce)) {
     if (browserName === 'headlessChrome') {
       const caps = webdriver.Capabilities.chrome();
       caps.set('goog:chromeOptions', {
@@ -48,35 +48,42 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
 
   let url;
   let capabilities;
-  if (browserInfo.url) {
-    url = browserInfo.url;
-    capabilities = {
-      ...browserInfo,
-      [Capability.BROWSER_NAME]: browserName,
-    };
-    delete capabilities.url;
-  } else if (browserInfo.useSauce) {
+  if (useRemote) {
+    const remote = browserInfo.remoteSeleniumGrid;
+    if (remote) {
+      url = remote.url;
+      capabilities = {
+        ...remote,
+        [Capability.BROWSER_NAME]: browserName,
+      };
+      delete capabilities.url;
+    }
+  } else if (useSauce) {
     // handle legacy `sauce` object
     const sauce = browserInfo.sauce;
-    url = `http://${sauce.username}:${sauce.accessKey}@ondemand.saucelabs.com/wd/hub`;
+    if (sauce) {
+      url = `http://${sauce.username}:${sauce.accessKey}@ondemand.saucelabs.com/wd/hub`;
+      capabilities = {
+        [Capability.BROWSER_NAME]: browserName,
+        build: sauce.build,
+        tags: sauce.tags,
+      };
+
+      capabilities[Capability.PLATFORM_NAME] = sauce.os;
+      capabilities[Capability.BROWSER_VERSION] = sauce.browserVersion;
+      capabilities['sauce:options'] = {
+        'tunnel-identifier': sauce.tunnelIdentifier,
+      };
+    }
+  } else {
     capabilities = {
       [Capability.BROWSER_NAME]: browserName,
-      build: sauce.build,
-      tags: sauce.tags,
     };
-
-    capabilities[Capability.PLATFORM_NAME] = sauce.os;
-    capabilities[Capability.BROWSER_VERSION] = sauce.browserVersion;
-    capabilities['sauce:options'] = {
-      'tunnel-identifier': sauce.tunnelIdentifier,
-    };
-  } else {
-    url = 'http://@localhost:4445/wd/hub';
   }
 
   return webdriverBuilder
     .withCapabilities(capabilities)
-    .usingServer(url)
+    .usingServer(url || 'http://localhost:4445/wd/hub')
     .build();
 }
 

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -57,8 +57,8 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
     delete capabilities.url;
   } else if (browserInfo.useSauce) {
     // handle legacy `sauce` object
-    url = `http://${sauce.username}:${sauce.accessKey}@ondemand.saucelabs.com/wd/hub`;
     const sauce = browserInfo.sauce;
+    url = `http://${sauce.username}:${sauce.accessKey}@ondemand.saucelabs.com/wd/hub`;
     capabilities = {
       [Capability.BROWSER_NAME]: browserName,
       build: sauce.build,

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -44,7 +44,7 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
   }
 
   const url = browserInfo.url;
-  const capabilities = {...browserInfo, browserName};
+  const capabilities = { ...browserInfo, browserName };
   delete capabilities.url;
 
   return webdriverBuilder

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -3,7 +3,9 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
     Capability = webdriver.Capability;
 
   webdriverBuilder = webdriverBuilder || new webdriver.Builder();
-  const remote = typeof browserInfo === 'object' && (browserInfo.useSauce || browserInfo.url);
+  const remote =
+    typeof browserInfo === 'object' &&
+    (browserInfo.useSauce || browserInfo.url);
   let browserName;
 
   if (typeof browserInfo === 'string') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-browser-runner",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Serve and run your Jasmine specs in a browser",
   "bin": "bin/jasmine-browser-runner",
   "exports": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-browser-runner",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Serve and run your Jasmine specs in a browser",
   "bin": "bin/jasmine-browser-runner",
   "exports": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-browser-runner",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Serve and run your Jasmine specs in a browser",
   "bin": "bin/jasmine-browser-runner",
   "exports": "./index.js",

--- a/spec/fixtures/remoteGridIntegration/jasmine-browser.json
+++ b/spec/fixtures/remoteGridIntegration/jasmine-browser.json
@@ -8,15 +8,18 @@
   "helpers": [],
   "random": true,
   "browser": {
-    "url": "https://ondemand.saucelabs.com/wd/hub",
-    "browserName": "<< JASMINE_BROWSER >>",
-    "browserVersion": "<< SAUCE_BROWSER_VERSION >>",
-    "platformName": "<< SAUCE_OS >>",
-    "sauce:options": {
-      "tags": ["jasmine-browser"],
-      "tunnel-identifier": "<< SAUCE_TUNNEL_IDENTIFIER >>",
-      "username": "<< SAUCE_USERNAME >>",
-      "accessKey": "<< SAUCE_ACCESS_KEY >>"
+    "name": "<< JASMINE_BROWSER >>",
+    "useRemoteSeleniumGrid": true,
+    "remoteSeleniumGrid": {
+      "url": "https://ondemand.saucelabs.com/wd/hub",
+      "browserVersion": "<< SAUCE_BROWSER_VERSION >>",
+      "platformName": "<< SAUCE_OS >>",
+      "sauce:options": {
+        "tags": ["jasmine-browser"],
+        "tunnel-identifier": "<< SAUCE_TUNNEL_IDENTIFIER >>",
+        "username": "<< SAUCE_USERNAME >>",
+        "accessKey": "<< SAUCE_ACCESS_KEY >>"
+      }
     }
   }
 }

--- a/spec/fixtures/remoteGridIntegration/jasmine-browser.json
+++ b/spec/fixtures/remoteGridIntegration/jasmine-browser.json
@@ -3,7 +3,7 @@
   "srcFiles": [],
   "specDir": ".",
   "specFiles": [
-    "sauceParamsSpec.js"
+    "remoteGridParamsSpec.js"
   ],
   "helpers": [],
   "random": true,

--- a/spec/fixtures/remoteGridIntegration/jasmine-browser.json
+++ b/spec/fixtures/remoteGridIntegration/jasmine-browser.json
@@ -8,13 +8,13 @@
   "helpers": [],
   "random": true,
   "browser": {
-    "name": "<< JASMINE_BROWSER >>",
-    "useSauce": true,
-    "sauce": {
-      "browserVersion": "<< SAUCE_BROWSER_VERSION >>",
-      "os": "<< SAUCE_OS >>",
+    "url": "https://ondemand.saucelabs.com/wd/hub",
+    "browserName": "<< JASMINE_BROWSER >>",
+    "browserVersion": "<< SAUCE_BROWSER_VERSION >>",
+    "platformName": "<< SAUCE_OS >>",
+    "sauce:options": {
       "tags": ["jasmine-browser"],
-      "tunnelIdentifier": "<< SAUCE_TUNNEL_IDENTIFIER >>",
+      "tunnel-identifier": "<< SAUCE_TUNNEL_IDENTIFIER >>",
       "username": "<< SAUCE_USERNAME >>",
       "accessKey": "<< SAUCE_ACCESS_KEY >>"
     }

--- a/spec/fixtures/remoteGridIntegration/remoteGridParamsSpec.js
+++ b/spec/fixtures/remoteGridIntegration/remoteGridParamsSpec.js
@@ -1,0 +1,6 @@
+
+describe('remote grid parameter handling', function() {
+  it('was run in the expected browser', function() {
+    expect(navigator.userAgent.toString()).toMatch(<< EXPECTED >>);
+  });
+});

--- a/spec/fixtures/sauceIntegration/jasmine-browser.json
+++ b/spec/fixtures/sauceIntegration/jasmine-browser.json
@@ -8,13 +8,13 @@
   "helpers": [],
   "random": true,
   "browser": {
-    "name": "<< JASMINE_BROWSER >>",
-    "useSauce": true,
-    "sauce": {
-      "browserVersion": "<< SAUCE_BROWSER_VERSION >>",
-      "os": "<< SAUCE_OS >>",
+    "url": "https://ondemand.saucelabs.com/wd/hub",
+    "browserName": "<< JASMINE_BROWSER >>",
+    "browserVersion": "<< SAUCE_BROWSER_VERSION >>",
+    "platformName": "<< SAUCE_OS >>",
+    "sauce:options": {
       "tags": ["jasmine-browser"],
-      "tunnelIdentifier": "<< SAUCE_TUNNEL_IDENTIFIER >>",
+      "tunnel-identifier": "<< SAUCE_TUNNEL_IDENTIFIER >>",
       "username": "<< SAUCE_USERNAME >>",
       "accessKey": "<< SAUCE_ACCESS_KEY >>"
     }

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -78,7 +78,7 @@ describe('index', function() {
           );
 
           await expectAsync(promise).toBeRejectedWithError(
-            "Can't specify a port when browser.useSauce is true"
+            "Can't specify a port when browser.useSauce is true or browser.url is set"
           );
           expect(this.server.start).not.toHaveBeenCalled();
         });

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -78,7 +78,7 @@ describe('index', function() {
           );
 
           await expectAsync(promise).toBeRejectedWithError(
-            "Can't specify a port when browser.useSauce is true or browser.url is set"
+            "Can't specify a port when browser.useSauce or browser.useRemoteSeleniumGrid is true"
           );
           expect(this.server.start).not.toHaveBeenCalled();
         });

--- a/spec/remoteGridIntegrationSpec.js
+++ b/spec/remoteGridIntegrationSpec.js
@@ -67,7 +67,7 @@ describe('remote grid parameter handling', function() {
         const jasmineBrowserDir = process.cwd();
         let timedOut = false;
         let timerId;
-        console.log('Sauce test may take a minute or two');
+        console.log('remote grid test may take a minute or two');
 
         const jasmineBrowserProcess = exec(
           `"${jasmineBrowserDir}/bin/jasmine-browser-runner" runSpecs --config=jasmine-browser.json`,
@@ -114,7 +114,7 @@ describe('remote grid parameter handling', function() {
     );
 
     function createSuite() {
-      const dir = fs.mkdtempSync(`${os.tmpdir()}/jasmine-browser-sauce-`);
+      const dir = fs.mkdtempSync(`${os.tmpdir()}/jasmine-browser-remote-grid-`);
       processTemplate(
         'spec/fixtures/remoteGridIntegration/jasmine-browser.json',
         `${dir}/jasmine-browser.json`,

--- a/spec/remoteGridIntegrationSpec.js
+++ b/spec/remoteGridIntegrationSpec.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const os = require('os');
+const { exec } = require('child_process');
+
+describe('remote grid parameter handling', function() {
+  // To reduce the amount of output that devs have to scroll past, pend a single
+  // spec and don't create the rest if Sauce isn't available.
+  if (
+    !(
+      process.env.USE_SAUCE &&
+      process.env.SAUCE_USERNAME &&
+      process.env.SAUCE_ACCESS_KEY
+    )
+  ) {
+    it('passes params to Saucelabs correctly', function() {
+      pending(
+        "Can't run remote grid integration tests unless USE_SAUCE, SAUCE_USERNAME, and SAUCE_ACCESS_KEY are set"
+      );
+    });
+    return;
+  }
+
+  // These specs use browser+version+OS combos that are supported by Saucelabs.
+  // When more than one OS is supported, we use the older one to make sure that
+  // the OS parameter is actually being passed correctly. (Saucelabs generally
+  // defaults to the newest OS that has the requested browser version if the OS
+  // is not specified.)
+
+  createSpec('firefox', '', '', /Gecko\/[0-9]+ Firefox\/[0-9.]+$/);
+  createSpec(
+    'firefox',
+    '102',
+    'Windows 10',
+    /Windows NT 10.0;.* Firefox\/102\.0$/
+  );
+  createSpec('chrome', '', '', /\(KHTML, like Gecko\) Chrome\/[0-9]+[0-9.]+/);
+  createSpec(
+    'safari',
+    '15',
+    'macOS 12',
+    // Safari on 12.x reports the OS as 10_15_7
+    /Mac OS X 10_15.*Version\/15[0-9.]+ Safari/
+  );
+  createSpec(
+    'safari',
+    '16',
+    'macOS 12',
+    // Safari on 12.x reports the OS as 10_15_7
+    /Mac OS X 10_15.*Version\/16[0-9.]+ Safari/
+  );
+  createSpec(
+    'MicrosoftEdge',
+    '',
+    'Windows 10',
+    /Windows NT 10\.0.*Edg\/[0-9]+\.[0-9.]+$/
+  );
+
+  function createSpec(browser, version, sauceOS, expectedUserAgentRegex) {
+    const displayVersion = version
+      ? `version ${version}`
+      : 'unspecified version';
+    const displayOS = sauceOS ? `OS ${sauceOS}` : 'unspecified OS';
+    it(
+      `passes browser ${browser}, ${displayVersion}, and ${displayOS} correctly`,
+      function(done) {
+        const suiteDir = createSuite();
+        const jasmineBrowserDir = process.cwd();
+        let timedOut = false;
+        let timerId;
+        console.log('Sauce test may take a minute or two');
+
+        const jasmineBrowserProcess = exec(
+          `"${jasmineBrowserDir}/bin/jasmine-browser-runner" runSpecs --config=jasmine-browser.json`,
+          { cwd: suiteDir },
+          function(err, stdout, stderr) {
+            try {
+              if (timedOut) {
+                return;
+              }
+
+              clearTimeout(timerId);
+
+              if (!err) {
+                expect(stdout).toContain('1 spec, 0 failures');
+                done();
+              } else {
+                if (err.code !== 1 || stdout === '' || stderr !== '') {
+                  // Some kind of unexpected failure happened. Include all the info
+                  // that we have.
+                  done.fail(
+                    `Child suite failed with error:\n${err}\n\n` +
+                      `stdout:\n${stdout}\n\n` +
+                      `stderr:\n${stderr}`
+                  );
+                } else {
+                  // A normal suite failure. Just include the output.
+                  done.fail(`Child suite failed with output:\n${stdout}`);
+                }
+              }
+            } catch (e) {
+              done.fail(e);
+            }
+          }
+        );
+
+        timerId = setTimeout(function() {
+          // Kill the child processs if we're about to time out, to free up
+          // the port.
+          timedOut = true;
+          jasmineBrowserProcess.kill();
+        }, 239 * 1000);
+      },
+      240 * 1000
+    );
+
+    function createSuite() {
+      const dir = fs.mkdtempSync(`${os.tmpdir()}/jasmine-browser-sauce-`);
+      processTemplate(
+        'spec/fixtures/remoteGridIntegration/jasmine-browser.json',
+        `${dir}/jasmine-browser.json`,
+        {
+          JASMINE_BROWSER: browser,
+          SAUCE_BROWSER_VERSION: version,
+          SAUCE_OS: sauceOS,
+          SAUCE_TUNNEL_IDENTIFIER: process.env.SAUCE_TUNNEL_IDENTIFIER || '',
+          SAUCE_USERNAME: process.env.SAUCE_USERNAME,
+          SAUCE_ACCESS_KEY: process.env.SAUCE_ACCESS_KEY,
+        }
+      );
+      processTemplate(
+        'spec/fixtures/remoteGridIntegration/remoteGridParamsSpec.js',
+        `${dir}/remoteGridParamsSpec.js`,
+        { EXPECTED: expectedUserAgentRegex }
+      );
+      return dir;
+    }
+
+    function processTemplate(inPath, outPath, vars) {
+      const template = fs.readFileSync(inPath, { encoding: 'utf8' });
+
+      const output = Object.keys(vars).reduce(function(prev, k) {
+        return prev.replace(`<< ${k} >>`, vars[k]);
+      }, template);
+
+      fs.writeFileSync(outPath, output);
+    }
+  }
+});

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -87,7 +87,15 @@ describe('webdriver', function() {
     });
   });
 
-  describe('When browserInfo is an object with url set to some value', function() {
+  describe('When browserInfo is an object', function() {
+    it('uses browserInfo.name as the browser name', function() {
+      const builder = new MockWebdriverBuilder();
+
+      buildWebdriver({ useSauce: true, sauce: {}, name: 'IE' }, builder);
+
+      expect(builder.capabilities.browserName).toEqual('IE');
+    });
+
     it('uses browserInfo.browserName as the browser name', function() {
       const builder = new MockWebdriverBuilder();
 
@@ -100,6 +108,16 @@ describe('webdriver', function() {
       );
 
       expect(builder.capabilities.browserName).toEqual('IE');
+    });
+
+    describe('When browserInfo.name is undefined', function() {
+      it('defaults to firefox', function() {
+        const builder = new MockWebdriverBuilder();
+
+        buildWebdriver({ useSauce: true, sauce: {} }, builder);
+
+        expect(builder.capabilities.browserName).toEqual('firefox');
+      });
     });
 
     describe('When browserInfo.browserName is undefined', function() {
@@ -118,6 +136,17 @@ describe('webdriver', function() {
     });
 
     it('uses Sauce', function() {
+      const builder = new MockWebdriverBuilder();
+
+      buildWebdriver(
+        { useSauce: true, sauce: {}, name: 'a browser name' },
+        builder
+      );
+
+      expect(builder.server).toMatch(/saucelabs/);
+    });
+
+    it('can also use Sauce via url', function() {
       const builder = new MockWebdriverBuilder();
 
       buildWebdriver(

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -131,73 +131,98 @@ describe('webdriver', function() {
       expect(builder.server).toMatch(/saucelabs/);
     });
 
-    it('uses W3C keys', function() {
-      const builder = new MockWebdriverBuilder();
-      function makeBrowser(name, version) {
-        buildWebdriver(
-          {
-            url: 'https://ondemand.saucelabs.com/wd/hub',
-            browserName: name,
-            platformName: 'MULTICS',
-            browserVersion: version,
-            'sauce:options': {
-              'tunnel-identifier': 'a tunnel id',
-            },
-          },
-          builder
-        );
-      }
+    const configMode = [
+      { mode: makeBrowser, description: 'config format containing url' },
+      {
+        mode: makeLegacyModeBrowser,
+        description: 'config format containing sauce object',
+      },
+    ];
+    configMode.forEach(modeObj => {
+      it(`uses W3C keys when using ${modeObj.description}`, function() {
+        const builder = new MockWebdriverBuilder();
 
-      makeBrowser('safari', '12');
-      expect(builder.capabilities.platformName).toEqual('MULTICS');
-      expect(builder.capabilities.browserVersion).toEqual('12');
-      expect(builder.capabilities['sauce:options']).toEqual({
-        'tunnel-identifier': 'a tunnel id',
-      });
-      expect(builder.capabilities.platform).toBeUndefined();
-      expect(builder.capabilities.version).toBeUndefined();
-      expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
+        modeObj.mode('safari', '12', builder);
+        expect(builder.capabilities.platformName).toEqual('MULTICS');
+        expect(builder.capabilities.browserVersion).toEqual('12');
+        expect(builder.capabilities['sauce:options']).toEqual({
+          'tunnel-identifier': 'a tunnel id',
+        });
+        expect(builder.capabilities.platform).toBeUndefined();
+        expect(builder.capabilities.version).toBeUndefined();
+        expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
 
-      makeBrowser('firefox', '68');
-      expect(builder.capabilities.platformName).toEqual('MULTICS');
-      expect(builder.capabilities.browserVersion).toEqual('68');
-      expect(builder.capabilities['sauce:options']).toEqual({
-        'tunnel-identifier': 'a tunnel id',
-      });
-      expect(builder.capabilities.platform).toBeUndefined();
-      expect(builder.capabilities.version).toBeUndefined();
-      expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
+        modeObj.mode('firefox', '68', builder);
+        expect(builder.capabilities.platformName).toEqual('MULTICS');
+        expect(builder.capabilities.browserVersion).toEqual('68');
+        expect(builder.capabilities['sauce:options']).toEqual({
+          'tunnel-identifier': 'a tunnel id',
+        });
+        expect(builder.capabilities.platform).toBeUndefined();
+        expect(builder.capabilities.version).toBeUndefined();
+        expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
 
-      makeBrowser('firefox', '');
-      expect(builder.capabilities.platformName).toEqual('MULTICS');
-      expect(builder.capabilities.browserVersion).toEqual('');
-      expect(builder.capabilities['sauce:options']).toEqual({
-        'tunnel-identifier': 'a tunnel id',
-      });
-      expect(builder.capabilities.platform).toBeUndefined();
-      expect(builder.capabilities.version).toBeUndefined();
-      expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
+        modeObj.mode('firefox', '', builder);
+        expect(builder.capabilities.platformName).toEqual('MULTICS');
+        expect(builder.capabilities.browserVersion).toEqual('');
+        expect(builder.capabilities['sauce:options']).toEqual({
+          'tunnel-identifier': 'a tunnel id',
+        });
+        expect(builder.capabilities.platform).toBeUndefined();
+        expect(builder.capabilities.version).toBeUndefined();
+        expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
 
-      makeBrowser('chrome', '');
-      expect(builder.capabilities.platformName).toEqual('MULTICS');
-      expect(builder.capabilities.browserVersion).toEqual('');
-      expect(builder.capabilities['sauce:options']).toEqual({
-        'tunnel-identifier': 'a tunnel id',
-      });
-      expect(builder.capabilities.platform).toBeUndefined();
-      expect(builder.capabilities.version).toBeUndefined();
-      expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
+        modeObj.mode('chrome', '', builder);
+        expect(builder.capabilities.platformName).toEqual('MULTICS');
+        expect(builder.capabilities.browserVersion).toEqual('');
+        expect(builder.capabilities['sauce:options']).toEqual({
+          'tunnel-identifier': 'a tunnel id',
+        });
+        expect(builder.capabilities.platform).toBeUndefined();
+        expect(builder.capabilities.version).toBeUndefined();
+        expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
 
-      makeBrowser('microsoftEdge', '');
-      expect(builder.capabilities.platformName).toEqual('MULTICS');
-      expect(builder.capabilities.browserVersion).toEqual('');
-      expect(builder.capabilities['sauce:options']).toEqual({
-        'tunnel-identifier': 'a tunnel id',
+        modeObj.mode('microsoftEdge', '', builder);
+        expect(builder.capabilities.platformName).toEqual('MULTICS');
+        expect(builder.capabilities.browserVersion).toEqual('');
+        expect(builder.capabilities['sauce:options']).toEqual({
+          'tunnel-identifier': 'a tunnel id',
+        });
+        expect(builder.capabilities.platform).toBeUndefined();
+        expect(builder.capabilities.version).toBeUndefined();
+        expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
       });
-      expect(builder.capabilities.platform).toBeUndefined();
-      expect(builder.capabilities.version).toBeUndefined();
-      expect(builder.capabilities.tunnelIdentifier).toBeUndefined();
     });
+
+    function makeBrowser(name, version, builder) {
+      buildWebdriver(
+        {
+          url: 'https://ondemand.saucelabs.com/wd/hub',
+          browserName: name,
+          platformName: 'MULTICS',
+          browserVersion: version,
+          'sauce:options': {
+            'tunnel-identifier': 'a tunnel id',
+          },
+        },
+        builder
+      );
+    }
+
+    function makeLegacyModeBrowser(name, version, builder) {
+      buildWebdriver(
+        {
+          useSauce: true,
+          name: name,
+          sauce: {
+            os: 'MULTICS',
+            browserVersion: version,
+            tunnelIdentifier: 'a tunnel id',
+          },
+        },
+        builder
+      );
+    }
   });
 });
 

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -58,16 +58,16 @@ describe('webdriver', function() {
       });
     });
 
-    describe('When browserInfo is an object without useSauce=true', function() {
-      it('uses browserInfo.name as the browser name', function() {
+    describe('When browserInfo is an object without url', function() {
+      it('uses browserInfo.browserName as the browser name', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({ name: 'IE' }, builder);
+        buildWebdriver({ browserName: 'IE' }, builder);
 
         expect(builder.browserName).toEqual('IE');
       });
 
-      describe('When browserInfo.name is undefined', function() {
+      describe('When browserInfo.browserName is undefined', function() {
         it('defaults to firefox', function() {
           const builder = new MockWebdriverBuilder();
 
@@ -80,27 +80,32 @@ describe('webdriver', function() {
       it('does not use Sauce', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({ name: 'a browser name' }, builder);
+        buildWebdriver({ browserName: 'a browser name' }, builder);
 
         expect(builder.server).not.toMatch(/saucelabs/);
       });
     });
   });
 
-  describe('When browserInfo is an object with useSauce=true', function() {
-    it('uses browserInfo.name as the browser name', function() {
+  describe('When browserInfo is an object with url set to some value', function() {
+    it('uses browserInfo.browserName as the browser name', function() {
       const builder = new MockWebdriverBuilder();
 
-      buildWebdriver({ useSauce: true, sauce: {}, name: 'IE' }, builder);
+      buildWebdriver({ 
+        url: 'https://ondemand.saucelabs.com/wd/hub', 
+        browserName: 'IE' 
+      }, builder);
 
       expect(builder.capabilities.browserName).toEqual('IE');
     });
 
-    describe('When browserInfo.name is undefined', function() {
+    describe('When browserInfo.browserName is undefined', function() {
       it('defaults to firefox', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({ useSauce: true, sauce: {} }, builder);
+        buildWebdriver({ 
+          url: 'https://ondemand.saucelabs.com/wd/hub'
+        }, builder);
 
         expect(builder.capabilities.browserName).toEqual('firefox');
       });
@@ -110,7 +115,10 @@ describe('webdriver', function() {
       const builder = new MockWebdriverBuilder();
 
       buildWebdriver(
-        { useSauce: true, sauce: {}, name: 'a browser name' },
+        { 
+          url: 'https://ondemand.saucelabs.com/wd/hub',
+          browserName: 'a browser name'
+        },
         builder
       );
 
@@ -122,12 +130,12 @@ describe('webdriver', function() {
       function makeBrowser(name, version) {
         buildWebdriver(
           {
-            useSauce: true,
-            name: name,
-            sauce: {
-              os: 'MULTICS',
-              browserVersion: version,
-              tunnelIdentifier: 'a tunnel id',
+            url: 'https://ondemand.saucelabs.com/wd/hub',
+            browserName: name,
+            platformName: 'MULTICS',
+            browserVersion: version,
+            "sauce:options": {
+              "tunnel-identifier": 'a tunnel id',
             },
           },
           builder

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -58,36 +58,65 @@ describe('webdriver', function() {
       });
     });
 
-    describe('When browserInfo is an object without url', function() {
-      it('uses browserInfo.browserName as the browser name', function() {
+    describe('When browserInfo is an object with useRemoteSeleniumGrid set to true', function() {
+      it('uses browserInfo.name as the browser name', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({ browserName: 'IE' }, builder);
+        buildWebdriver({ name: 'IE', useRemoteSeleniumGrid: true }, builder);
 
-        expect(builder.browserName).toEqual('IE');
+        expect(builder.capabilities.browserName).toEqual('IE');
       });
 
-      describe('When browserInfo.browserName is undefined', function() {
+      describe('When browserInfo.name is undefined', function() {
         it('defaults to firefox', function() {
           const builder = new MockWebdriverBuilder();
 
-          buildWebdriver({}, builder);
+          buildWebdriver({ useRemoteSeleniumGrid: true }, builder);
 
-          expect(builder.browserName).toEqual('firefox');
+          expect(builder.capabilities.browserName).toEqual('firefox');
         });
       });
 
       it('does not use Sauce', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({ browserName: 'a browser name' }, builder);
+        buildWebdriver(
+          {
+            name: 'a browser name',
+            useRemoteSeleniumGrid: true,
+            remoteSeleniumGrid: {
+              url: 'a url to use',
+            },
+          },
+          builder
+        );
 
-        expect(builder.server).not.toMatch(/saucelabs/);
+        expect(builder.server).toMatch(/(a url to use)/);
+      });
+
+      it('will use localhost grid hub url if no url specified', function() {
+        const builder = new MockWebdriverBuilder();
+
+        buildWebdriver(
+          {
+            name: 'a browser name',
+            useRemoteSeleniumGrid: true,
+            remoteSeleniumGrid: {
+              'sauce:options': {
+                username: 'a user',
+                accessKey: 'a key',
+              },
+            },
+          },
+          builder
+        );
+
+        expect(builder.server).toEqual('http://localhost:4445/wd/hub');
       });
     });
   });
 
-  describe('When browserInfo is an object', function() {
+  describe('When browserInfo is an object with useSauce set to true', function() {
     it('uses browserInfo.name as the browser name', function() {
       const builder = new MockWebdriverBuilder();
 
@@ -96,16 +125,10 @@ describe('webdriver', function() {
       expect(builder.capabilities.browserName).toEqual('IE');
     });
 
-    it('uses browserInfo.browserName as the browser name', function() {
+    it('uses browserInfo.name as the browser name', function() {
       const builder = new MockWebdriverBuilder();
 
-      buildWebdriver(
-        {
-          url: 'https://ondemand.saucelabs.com/wd/hub',
-          browserName: 'IE',
-        },
-        builder
-      );
+      buildWebdriver({ useSauce: true, name: 'IE' }, builder);
 
       expect(builder.capabilities.browserName).toEqual('IE');
     });
@@ -120,16 +143,11 @@ describe('webdriver', function() {
       });
     });
 
-    describe('When browserInfo.browserName is undefined', function() {
+    describe('When browserInfo.name is undefined', function() {
       it('defaults to firefox', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver(
-          {
-            url: 'https://ondemand.saucelabs.com/wd/hub',
-          },
-          builder
-        );
+        buildWebdriver({}, builder);
 
         expect(builder.capabilities.browserName).toEqual('firefox');
       });
@@ -146,13 +164,16 @@ describe('webdriver', function() {
       expect(builder.server).toMatch(/saucelabs/);
     });
 
-    it('can also use Sauce via url', function() {
+    it('can also use Sauce via remoteSeleniumGrid object', function() {
       const builder = new MockWebdriverBuilder();
 
       buildWebdriver(
         {
-          url: 'https://ondemand.saucelabs.com/wd/hub',
-          browserName: 'a browser name',
+          name: 'a browser name',
+          useRemoteSeleniumGrid: true,
+          remoteSeleniumGrid: {
+            url: 'https://ondemand.saucelabs.com/wd/hub',
+          },
         },
         builder
       );
@@ -161,7 +182,10 @@ describe('webdriver', function() {
     });
 
     const configMode = [
-      { mode: makeBrowser, description: 'config format containing url' },
+      {
+        mode: makeBrowser,
+        description: 'config format containing remoteSeleniumGrid object',
+      },
       {
         mode: makeLegacyModeBrowser,
         description: 'config format containing sauce object',
@@ -226,12 +250,15 @@ describe('webdriver', function() {
     function makeBrowser(name, version, builder) {
       buildWebdriver(
         {
-          url: 'https://ondemand.saucelabs.com/wd/hub',
-          browserName: name,
-          platformName: 'MULTICS',
-          browserVersion: version,
-          'sauce:options': {
-            'tunnel-identifier': 'a tunnel id',
+          name: name,
+          useRemoteSeleniumGrid: true,
+          remoteSeleniumGrid: {
+            url: 'https://ondemand.saucelabs.com/wd/hub',
+            platformName: 'MULTICS',
+            browserVersion: version,
+            'sauce:options': {
+              'tunnel-identifier': 'a tunnel id',
+            },
           },
         },
         builder

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -71,7 +71,10 @@ describe('webdriver', function() {
         it('defaults to firefox', function() {
           const builder = new MockWebdriverBuilder();
 
-          buildWebdriver({ useRemoteSeleniumGrid: true }, builder);
+          buildWebdriver(
+            { useRemoteSeleniumGrid: true, remoteSeleniumGrid: {} },
+            builder
+          );
 
           expect(builder.capabilities.browserName).toEqual('firefox');
         });

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -113,6 +113,23 @@ describe('webdriver', function() {
 
         expect(builder.server).toEqual('http://localhost:4445/wd/hub');
       });
+
+      it('can also use Saucelabs', function() {
+        const builder = new MockWebdriverBuilder();
+
+        buildWebdriver(
+          {
+            name: 'a browser name',
+            useRemoteSeleniumGrid: true,
+            remoteSeleniumGrid: {
+              url: 'https://ondemand.saucelabs.com/wd/hub',
+            },
+          },
+          builder
+        );
+
+        expect(builder.server).toMatch(/saucelabs/);
+      });
     });
   });
 
@@ -147,7 +164,7 @@ describe('webdriver', function() {
       it('defaults to firefox', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({}, builder);
+        buildWebdriver({ useSauce: true }, builder);
 
         expect(builder.capabilities.browserName).toEqual('firefox');
       });
@@ -158,23 +175,6 @@ describe('webdriver', function() {
 
       buildWebdriver(
         { useSauce: true, sauce: {}, name: 'a browser name' },
-        builder
-      );
-
-      expect(builder.server).toMatch(/saucelabs/);
-    });
-
-    it('can also use Sauce via remoteSeleniumGrid object', function() {
-      const builder = new MockWebdriverBuilder();
-
-      buildWebdriver(
-        {
-          name: 'a browser name',
-          useRemoteSeleniumGrid: true,
-          remoteSeleniumGrid: {
-            url: 'https://ondemand.saucelabs.com/wd/hub',
-          },
-        },
         builder
       );
 

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -91,9 +91,9 @@ describe('webdriver', function() {
     it('uses browserInfo.browserName as the browser name', function() {
       const builder = new MockWebdriverBuilder();
 
-      buildWebdriver({ 
-        url: 'https://ondemand.saucelabs.com/wd/hub', 
-        browserName: 'IE' 
+      buildWebdriver({
+        url: 'https://ondemand.saucelabs.com/wd/hub',
+        browserName: 'IE',
       }, builder);
 
       expect(builder.capabilities.browserName).toEqual('IE');
@@ -103,8 +103,8 @@ describe('webdriver', function() {
       it('defaults to firefox', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({ 
-          url: 'https://ondemand.saucelabs.com/wd/hub'
+        buildWebdriver({
+          url: 'https://ondemand.saucelabs.com/wd/hub',
         }, builder);
 
         expect(builder.capabilities.browserName).toEqual('firefox');
@@ -115,9 +115,9 @@ describe('webdriver', function() {
       const builder = new MockWebdriverBuilder();
 
       buildWebdriver(
-        { 
+        {
           url: 'https://ondemand.saucelabs.com/wd/hub',
-          browserName: 'a browser name'
+          browserName: 'a browser name',
         },
         builder
       );
@@ -134,8 +134,8 @@ describe('webdriver', function() {
             browserName: name,
             platformName: 'MULTICS',
             browserVersion: version,
-            "sauce:options": {
-              "tunnel-identifier": 'a tunnel id',
+            'sauce:options': {
+              'tunnel-identifier': 'a tunnel id',
             },
           },
           builder

--- a/spec/webdriverSpec.js
+++ b/spec/webdriverSpec.js
@@ -91,10 +91,13 @@ describe('webdriver', function() {
     it('uses browserInfo.browserName as the browser name', function() {
       const builder = new MockWebdriverBuilder();
 
-      buildWebdriver({
-        url: 'https://ondemand.saucelabs.com/wd/hub',
-        browserName: 'IE',
-      }, builder);
+      buildWebdriver(
+        {
+          url: 'https://ondemand.saucelabs.com/wd/hub',
+          browserName: 'IE',
+        },
+        builder
+      );
 
       expect(builder.capabilities.browserName).toEqual('IE');
     });
@@ -103,9 +106,12 @@ describe('webdriver', function() {
       it('defaults to firefox', function() {
         const builder = new MockWebdriverBuilder();
 
-        buildWebdriver({
-          url: 'https://ondemand.saucelabs.com/wd/hub',
-        }, builder);
+        buildWebdriver(
+          {
+            url: 'https://ondemand.saucelabs.com/wd/hub',
+          },
+          builder
+        );
 
         expect(builder.capabilities.browserName).toEqual('firefox');
       });


### PR DESCRIPTION
### Changes:
* rather than direct integration with only Saucelabs, adds a more flexible configuration format supporting any selenium grid provider by modifying the `browser` configuration key to be capable of holding an object representing the selenium capabilities plus a `url` used to connect (the `url` is removed from the object being being passed to the remote session builder, but all other values are passed as-is)
* changes are backwards compatible so using `useSauce` with a `sauce` object in the configuration will still work as before

### Justification:
this project is listed on the Karma repo as a viable alternative to Karma now that it is no longer being updated. given this, there is a need to support more than just Saucelabs integration and since the landscape of Selenium-As-A-Service providers vastly differs in their capabilities requirements it makes more sense to take an approach of letting the user specify the required capabilities and hub url rather than trying to keep up with all the possible service providers by building direct integrations for each.

### Additional Notes:
* the `useSauce` integration does not work for users in the EU because Saucelabs expects users to use a region-based hub url like `https://ondemand.eu-central-1.saucelabs.com:443/wd/hub` when connecting. this provides further support for the need for a more flexible configuration that allows one to specify their grid hub url and capabilities