### PR TITLE
Add support for headers in the server configuration

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -19,13 +19,13 @@ class Server {
       options.useHtmlReporter === undefined ? true : options.useHtmlReporter;
     this.projectBaseDir = options.projectBaseDir || path.resolve();
     this.jasmineCore = options.jasmineCore || require('./jasmineCore');
-    this.jasmineCssFiles = this.jasmineCore.files.cssFiles.map(function(
+    this.jasmineCssFiles = this.jasmineCore.files.cssFiles.map(function (
       fileName
     ) {
       return unWindows(path.join('/__jasmine__', fileName));
     });
     this.jasmineJsFiles = this.jasmineCore.files.jsFiles
-      .map(function(fileName) {
+      .map(function (fileName) {
         return unWindows(path.join('/__jasmine__', fileName));
       })
       .concat(this.bootFiles());
@@ -39,7 +39,7 @@ class Server {
   }
 
   bootFiles() {
-    const bootFiles = this.jasmineCore.files.bootFiles.map(function(fileName) {
+    const bootFiles = this.jasmineCore.files.bootFiles.map(function (fileName) {
       return unWindows(path.join('/__boot__', fileName));
     });
     bootFiles.splice(1, 0, '/__config__/config.js');
@@ -57,7 +57,7 @@ class Server {
 
   getUrls(baseDir, globs, urlRoot) {
     return findFiles(path.join(this.projectBaseDir, baseDir), globs || []).map(
-      function(p) {
+      function (p) {
         return isUrl(p) ? p : unWindows(path.join(urlRoot, p));
       }
     );
@@ -134,6 +134,14 @@ class Server {
   start(serverOptions) {
     serverOptions = serverOptions || {};
     const app = express();
+    if (this.options.headers) {
+      app.use((req, res, next) => {
+        for (const [headerKey, headerValue] of Object.entries(this.options.headers)) {
+          res.append(headerKey, headerValue);
+        }
+        next();
+      });
+    }
 
     app.use('/__jasmine__', express.static(this.jasmineCore.files.path));
     app.use('/__boot__', express.static(this.jasmineCore.files.bootDir));
@@ -163,7 +171,7 @@ class Server {
     );
 
     const self = this;
-    app.get('/', function(req, res) {
+    app.get('/', function (req, res) {
       try {
         res.send(
           indexTemplate({
@@ -180,7 +188,7 @@ class Server {
         console.error(error);
       }
     });
-    app.get('/__config__/config.js', function(req, res) {
+    app.get('/__config__/config.js', function (req, res) {
       try {
         res.append('Content-type', 'application/javascript');
         res.send(
@@ -262,7 +270,7 @@ function isUrl(s) {
 
 function findFiles(baseDir, globs) {
   const { includeGlobs, excludeGlobs } = globs.reduce(
-    function(ongoing, g) {
+    function (ongoing, g) {
       const hasNegation = g.startsWith('!');
 
       if (hasNegation) {


### PR DESCRIPTION
Small change to add support to configure server response headers. 

The justification is that some client side libraries might require specific response headers in order to work. Currently it is not possible to modify the headers sent by Express.
  
