### PR TITLE
Update to latest selenium-webdriver version (v4.17.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ejs": "^3.1.6",
     "express": "^4.16.4",
     "glob": "^10.0.0",
-    "selenium-webdriver": "^4.12.0"
+    "selenium-webdriver": "^4.17.0"
   },
   "peerDependencies": {
     "jasmine-core": "^5.0.0"


### PR DESCRIPTION
To include [this fix][1] for correct detection of a chromium binary.

[1]: https://github.com/SeleniumHQ/selenium/pull/12890