### PR TITLE
Fix support for absolute paths in srcDir and specDir

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -57,11 +57,12 @@ class Server {
   }
 
   getUrls(baseDir, globs, urlRoot) {
-    return findFiles(path.join(this.projectBaseDir, baseDir), globs || []).map(
-      function(p) {
-        return isUrl(p) ? p : unWindows(path.join(urlRoot, p));
-      }
-    );
+    return findFiles(
+      path.resolve(this.projectBaseDir, baseDir),
+      globs || []
+    ).map(function(p) {
+      return isUrl(p) ? p : unWindows(path.join(urlRoot, p));
+    });
   }
 
   getSupportFiles() {
@@ -148,11 +149,15 @@ class Server {
     );
     app.use(
       '/__spec__',
-      this.express.static(path.join(this.projectBaseDir, this.options.specDir))
+      this.express.static(
+        path.resolve(this.projectBaseDir, this.options.specDir)
+      )
     );
     app.use(
       '/__src__',
-      this.express.static(path.join(this.projectBaseDir, this.options.srcDir))
+      this.express.static(
+        path.resolve(this.projectBaseDir, this.options.srcDir)
+      )
     );
 
     if (this.options.middleware) {
@@ -165,7 +170,10 @@ class Server {
 
     if (this.options.importMap) {
       const dir = this.options.importMap.moduleRootDir
-        ? path.join(this.projectBaseDir, this.options.importMap.moduleRootDir)
+        ? path.resolve(
+            this.projectBaseDir,
+            this.options.importMap.moduleRootDir
+          )
         : this.projectBaseDir;
       app.use('/__moduleRoot__', this.express.static(dir));
     }

--- a/spec/serverSpec.js
+++ b/spec/serverSpec.js
@@ -60,7 +60,7 @@ describe('server', function() {
       specFiles: ['**/*[sS]pec.js'],
     });
 
-    await server.start({ port: 0});
+    await server.start({ port: 0 });
 
     const baseUrl = `http://localhost:${server.port()}`;
 

--- a/spec/serverSpec.js
+++ b/spec/serverSpec.js
@@ -48,6 +48,29 @@ describe('server', function() {
     expect(server.projectBaseDir).toEqual(path.resolve());
   });
 
+  it('allows absolute paths for srcDir and specDir', async function() {
+    const projectDir = path.resolve(__dirname, 'fixtures/sampleProject');
+    const srcDir = path.resolve(projectDir, 'sources');
+    const specDir = path.resolve(projectDir, 'specs');
+    const server = new Server({
+      srcDir,
+      specDir,
+      srcFiles: ['thing2.js', '**/*.js'],
+      helpers: ['helpers/**/*.js'],
+      specFiles: ['**/*[sS]pec.js'],
+    });
+
+    await server.start({});
+
+    const baseUrl = `http://localhost:${server.port()}`;
+
+    // Even though the base dir isn't set on the server, we can still get the
+    // source file through the absolute path.
+    expect(server.projectBaseDir).toEqual(path.resolve());
+    expect(server.projectBaseDir).not.toEqual(projectDir);
+    await getFile(baseUrl + '/__src__/thing2.js');
+  });
+
   it('appends specified css files after Jasmines own', function() {
     const server = new Server({
       projectBaseDir: path.resolve(__dirname, 'fixtures/sampleProject'),

--- a/spec/serverSpec.js
+++ b/spec/serverSpec.js
@@ -60,7 +60,7 @@ describe('server', function() {
       specFiles: ['**/*[sS]pec.js'],
     });
 
-    await server.start({});
+    await server.start({ port: 0});
 
     const baseUrl = `http://localhost:${server.port()}`;
 
@@ -597,7 +597,7 @@ describe('server', function() {
       },
     });
 
-    await server.start();
+    await server.start({ port: 0 });
 
     expect(app.use).toHaveBeenCalledWith('/foo', middleware1);
     expect(app.use).toHaveBeenCalledWith('/bar', middleware2);


### PR DESCRIPTION
Instead of path.join(projectBaseDir, srcDir), we should use path.resolve(projectBaseDir, srcDir).  Where join() will always join paths, resolve() will resolve relative paths relative to the previous argument, but leave absolute paths alone.

Closes #15