### PR TITLE
Add ` jasmine-core` to Rails setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ whether you use the Asset Pipeline or Webpacker.
 
 ### Webpacker
 
-1. Run `yarn add --dev jasmine-browser-runner`.
+1. Run `yarn add --dev jasmine-browser-runner jasmine-core`.
 2. Run `npx jasmine-browser-runner init`.
 3. Edit `spec/support/jasmine-browser.json` as follows:
 ```


### PR DESCRIPTION
I ran

```
yarn add --dev jasmine-browser-runner
npx jasmine-browser-runner init
```

and got an error saying `jasmine-core` wasn't installed.

After installing `jasmine-core` I was able to run `npx jasmine-browser-runner init` and create `spec/support/jasmine-browser.json`