### PR TITLE
Support hideDisabled in runner.js

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -80,6 +80,11 @@ const subCommands = [
         type: 'string',
         description: 'which local browser to launch',
       },
+      {
+        name: 'hideDisabled',
+        type: 'bool',
+        description: 'hide disabled tests',
+      },
     ]),
   },
 ];

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -76,6 +76,7 @@ function urlParams(runOptions) {
         random: runOptions.random,
         seed: runOptions.seed,
         spec: runOptions.filter,
+        hideDisabled: runOptions.hideDisabled,
       })
     )
   );


### PR DESCRIPTION
We have slow painting of the gray dots when we do not process all specs like having `fit`. This way the user can push that options into the url.