### PR TITLE
Add modulesWithSideEffectsInSrcFiles to allow esm in srcFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,11 @@ config field to something that's high enough up to include both spec and source
 files, and set `srcFiles` to `[]`. You can autogenerate such a configuration by
 running `npx jasmine-browser-runner init --esm`.
 
+If you want to load ES module source directly on load instead of loading it from
+the corresponding spec, set the `modulesWithSideEffectsInSrcFiles` config property to `true`.
+
 If you have specs or helper files that use top-level await, set the
-`enableTopLevelAwait` config property is set to `true`.
+`enableTopLevelAwait` config property to `true`.
 
 [Import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap)
 are also supported:

--- a/lib/examples/default_esm_config.mjs
+++ b/lib/examples/default_esm_config.mjs
@@ -11,6 +11,8 @@ export default {
     "spec/helpers/**/*.?(m)js"
   ],
   esmFilenameExtension: ".mjs",
+  // Set to true if you need to load module src files instead of loading via the spec files.
+  modulesWithSideEffectsInSrcFiles: false,
   // Allows the use of top-level await in src/spec/helper files. This is off by
   // default because it makes files load more slowly.
   enableTopLevelAwait: false,

--- a/lib/server.js
+++ b/lib/server.js
@@ -82,8 +82,11 @@ class Server {
       this.options.srcFiles,
       '/__src__'
     ).filter(url => {
-      // Exclude ES modules. These will be loaded by other ES modules.
-      return !url.endsWith(this.options.esmFilenameExtension);
+      // Exclude ES modules by default. These will be loaded by other ES modules.
+      return (
+        this.options.modulesWithSideEffectsInSrcFiles ||
+        !url.endsWith(this.options.esmFilenameExtension)
+      );
     });
     const helperUrls = this.getUrls(
       this.options.specDir,
@@ -191,6 +194,8 @@ class Server {
             esmFilenameExtension: self.options.esmFilenameExtension,
             importMap: self.importMap(),
             enableTopLevelAwait: self.options.enableTopLevelAwait || false,
+            modulesWithSideEffectsInSrcFiles:
+              self.options.modulesWithSideEffectsInSrcFiles || false,
           })
         );
       } catch (error) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -154,6 +154,16 @@
  * @default false
  */
 /**
+ * If set to true jasmine loads also ES Modules which are included in SrcFiles.
+ * This option is off by default because in most scenarios it is better to load the
+ * module under test from the test itself.
+ * But if the module has wanted side effects (like for example polyfills) you can
+ * interleave ES module and classic scripts in your SrcFiles.
+ * @name Configuration#modulesWithSideEffectsInSrcFiles
+ * @type boolean | undefined
+ * @default false
+ */
+/**
  * <p>An optional map from paths to Express application middleware to mount on
  * those paths. This can be used to serve static files, proxy requests to
  * another server, etc.

--- a/run.html.ejs
+++ b/run.html.ejs
@@ -30,6 +30,8 @@
     <% userJsFiles.forEach(function(jsFile) { %>
       <% if (jsFile.endsWith(esmFilenameExtension)) { %>
         <script src="<%= jsFile %>" type="module"></script>
+      <% } else if (modulesWithSideEffectsInSrcFiles) { %>
+        <script src="<%= jsFile %>" type="text/javascript" defer></script>
       <% } else { %>
         <script src="<%= jsFile %>" type="text/javascript"></script>
       <% } %>

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/aSpec.js
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/aSpec.js
@@ -1,0 +1,4 @@
+it('verifies that ES modules in sources are automatically loaded in the correct order', function() {
+  expect(window._moduleWithSyncSideEffectLoaded).withContext('window._moduleWithSyncSideEffectLoaded').toBe(true);
+  expect(window._scriptSyncSuccess).withContext('window._scriptSyncSuccess').toBe(true);
+});

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/support/jasmine-browser.js
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/support/jasmine-browser.js
@@ -1,0 +1,16 @@
+module.exports = {
+  "srcDir": "src",
+  "srcFiles": [
+    "moduleWithSideEffects.mjs",
+    "scriptNeedsSideEffect.js"
+  ],
+  "specDir": "spec",
+  "specFiles": [
+    "aSpec.js"
+  ],
+  "random": false,
+  "modulesWithSideEffectsInSrcFiles": true,
+  "browser": {
+    "name": "headlessChrome"
+  }
+}

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/moduleWithSideEffects.mjs
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/moduleWithSideEffects.mjs
@@ -1,0 +1,1 @@
+window._moduleWithSyncSideEffectLoaded = true;

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/scriptNeedsSideEffect.js
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/scriptNeedsSideEffect.js
@@ -1,0 +1,5 @@
+if(window._moduleWithSyncSideEffectLoaded) {
+    window._scriptSyncSuccess = true;
+}else{
+    window._scriptSyncSuccess = false;
+}

--- a/spec/modulesWithSideEffectsInSrcFilesSpec.js
+++ b/spec/modulesWithSideEffectsInSrcFilesSpec.js
@@ -1,0 +1,18 @@
+const {
+  runJasmine,
+  expectSuccess,
+  timeoutMs,
+} = require('./integrationSupport');
+
+describe('ESM in Specs', function() {
+  it(
+    'optionally loads ESM files in spec',
+    async function() {
+      const result = await runJasmine(
+        'spec/fixtures/modulesWithSideEffectsInSrcFiles'
+      );
+      expectSuccess(result, '1 spec, 0 failures');
+    },
+    timeoutMs
+  );
+});


### PR DESCRIPTION
We have some ES modules which needs to be loaded as spec files.