### PR TITLE
Add withContext annotation for infrastructure code

### DIFF
--- a/spec/integrationSupport.js
+++ b/spec/integrationSupport.js
@@ -47,8 +47,12 @@ function runJasmine(cwd, { extraArgs, timeoutMs } = {}) {
 }
 
 function expectSuccess({ exitCode, stdout, stderr }, expectedOutput) {
-  expect(exitCode).toEqual(0);
-  expect(stdout).toContain(expectedOutput);
+  expect(exitCode)
+    .withContext('exitCode')
+    .toEqual(0);
+  expect(stdout)
+    .withContext('stdout')
+    .toContain(expectedOutput);
   jasmine.debugLog('stdout: ' + stdout);
   jasmine.debugLog('stderr: ' + stderr);
 }


### PR DESCRIPTION
This helped me a lot with getting #60 ready.

```
Failures:
1) ESM in Specs optionally loads ESM files in spec
  Message:
    exitCode: Expected 3 to equal 0.
  Stack:
        at <Jasmine>
        at expectSuccess (...\HolgerJeromin\jasmine-browser-runner\spec\integrationSupport.js:50:44)
        at UserContext.<anonymous> (...\HolgerJeromin\jasmine-browser-runner\spec\modulesWithSideEffectsInSrcFilesSpec.js:14:7)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
  Message:
    stdout:
        Expected 'Jasmine server is running here: http://localhost:55307
        Jasmine tests are here:         ...\HolgerJeromin\jasmine-browser-runner\spec\fixtures\modulesWithSideEffectsInSrcFiles\spec
        Source files are here:          ...\HolgerJeromin\jasmine-browser-runner\spec\fixtures\modulesWithSideEffectsInSrcFiles\src
        Running tests in the browser...
        Started
        F