### PR TITLE
Reduce __moduleRoot__ usage in importmap

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -114,14 +114,22 @@ class Server {
     const resultMap = {};
 
     if (importMap.imports) {
-      resultMap.imports = reifyRawSpecifierMap(importMap.imports);
+      resultMap.imports = reifyRawSpecifierMap(
+        importMap.imports,
+        this.options,
+        this.projectBaseDir
+      );
     }
 
     if (importMap.scopes) {
       resultMap.scopes = {};
 
       for (const [scope, map] of Object.entries(importMap.scopes)) {
-        resultMap.scopes[scope] = reifyRawSpecifierMap(map);
+        resultMap.scopes[scope] = reifyRawSpecifierMap(
+          map,
+          this.options,
+          this.projectBaseDir
+        );
       }
     }
 
@@ -377,12 +385,30 @@ function unWindows(filePath) {
 // paths that the run.html.ejs file will contain.  The `rawSpecifierMap` is not
 // the entire importMap. It is a key/value map that may be the "imports" value
 // or an individual map inside of "scopes"[someScope].
-function reifyRawSpecifierMap(rawSpecifierMap) {
+function reifyRawSpecifierMap(rawSpecifierMap, options, projectBaseDir) {
   const concreteMap = {};
 
   for (const [key, value] of Object.entries(rawSpecifierMap)) {
     if (value.match(/^https?:\/\//)) {
       concreteMap[key] = value; // pass through unchanged
+      continue;
+    }
+
+    const absoluteModuleRootDir = options.importMap.moduleRootDir
+      ? path.resolve(projectBaseDir, options.importMap.moduleRootDir)
+      : projectBaseDir;
+
+    const absolutePath = path.join(absoluteModuleRootDir, value);
+    const endsWithSeparator = value.endsWith('/') || value.endsWith('\\');
+
+    const resolvedSrcDir = path.join(absoluteModuleRootDir, options.srcDir);
+    const relativeFromSrcDir = path.relative(resolvedSrcDir, absolutePath);
+    if (!relativeFromSrcDir.startsWith('..')) {
+      // We are under srcDir: Reuse existing __src__ path
+      concreteMap[key] =
+        './' +
+        unWindows(path.join('__src__', relativeFromSrcDir)) +
+        (endsWithSeparator ? '/' : '');
     } else {
       concreteMap[key] = './' + unWindows(path.join('__moduleRoot__', value));
     }

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/aSpec.js
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/aSpec.js
@@ -2,3 +2,8 @@ it('verifies that ES modules in sources are automatically loaded in the correct 
   expect(window._moduleWithSyncSideEffectLoaded).withContext('window._moduleWithSyncSideEffectLoaded').toBe(true);
   expect(window._scriptSyncSuccess).withContext('window._scriptSyncSuccess').toBe(true);
 });
+it('verifies that ES modules in sources are loaded only once', function() {
+  return window.secondaryModuleLoading.then(() => {
+    expect(window._moduleRunCount).withContext('window._moduleRunCount').toBe(1);
+  });
+});

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/support/jasmine-browser.js
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/spec/support/jasmine-browser.js
@@ -12,5 +12,10 @@ module.exports = {
   "modulesWithSideEffectsInSrcFiles": true,
   "browser": {
     "name": "headlessChrome"
+  },
+  "importMap": {
+    "imports": {
+      "myPackage/moduleWithSideEffects.mjs": "./src/moduleWithSideEffects.mjs"
+    }
   }
 }

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/moduleWithSideEffects.mjs
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/moduleWithSideEffects.mjs
@@ -1,1 +1,7 @@
 window._moduleWithSyncSideEffectLoaded = true;
+
+if(!window._moduleRunCount) {
+    window._moduleRunCount = 1;
+} else {
+    window._moduleRunCount++;
+}

--- a/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/scriptNeedsSideEffect.js
+++ b/spec/fixtures/modulesWithSideEffectsInSrcFiles/src/scriptNeedsSideEffect.js
@@ -3,3 +3,13 @@ if(window._moduleWithSyncSideEffectLoaded) {
 }else{
     window._scriptSyncSuccess = false;
 }
+
+let resolve;
+window.secondaryModuleLoading = new Promise((intresolve) => {
+    resolve = intresolve;
+});
+// Load again to check if module is executed again or not (when loaded from the same path)
+import('myPackage/moduleWithSideEffects.mjs').then((_module) => {
+    // We are done
+    resolve();
+});

--- a/spec/modulesWithSideEffectsInSrcFilesSpec.js
+++ b/spec/modulesWithSideEffectsInSrcFilesSpec.js
@@ -11,7 +11,7 @@ describe('ESM in Specs', function() {
       const result = await runJasmine(
         'spec/fixtures/modulesWithSideEffectsInSrcFiles'
       );
-      expectSuccess(result, '1 spec, 0 failures');
+      expectSuccess(result, '2 specs, 0 failures');
     },
     timeoutMs
   );


### PR DESCRIPTION
Reuse a path in importMap when the path is already available via `__src__` or `__spec__`

fixes #64 