### PR TITLE
Add visual studio code (+derivates) launch config for tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,78 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "run esmIntegration",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}/spec/fixtures/esmIntegration",
+            "program": "${workspaceFolder}/bin/jasmine-browser-runner",
+            "args": ["serve"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "run esmIntegrationJsExtension",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}/spec/fixtures/esmIntegrationJsExtension",
+            "program": "${workspaceFolder}/bin/jasmine-browser-runner",
+            "args": ["serve"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "run importMap",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}/spec/fixtures/importMap",
+            "program": "${workspaceFolder}/bin/jasmine-browser-runner",
+            "args": ["serve", "--config=spec/support/jasmine-browser.module-root-dir.json"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "run modulesWithSideEffectsInSrcFiles",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}/spec/fixtures/modulesWithSideEffectsInSrcFiles",
+            "program": "${workspaceFolder}/bin/jasmine-browser-runner",
+            "args": ["serve"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "run random",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}/spec/fixtures/random",
+            "program": "${workspaceFolder}/bin/jasmine-browser-runner",
+            "args": ["serve"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
With that you can select the subtests in the [debugging user interface](https://code.visualstudio.com/Docs/editor/debugging#_user-interface) of visual studio code and derivates:

![image](https://github.com/user-attachments/assets/1bd7f6e3-3cf2-4e4c-929b-7e8747c4075f)

after that you have perfect debugging with breakpoints and variable inspection of the nodejs part.
Here with hover over `this.options`:

![image](https://github.com/user-attachments/assets/cde087c3-c192-447e-afe6-6285a628936f)
