### PR TITLE
Replace express with serve-static

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,4 @@
-const defaultExpress = require('express');
+const serveStatic = require('serve-static');
 const ejs = require('ejs');
 const fs = require('fs');
 const glob = require('glob');
@@ -18,7 +18,6 @@ class Server {
   constructor(options, deps) {
     this.options = { ...options };
     this._deps = deps || { http, https };
-    this.express = this.options.express || defaultExpress;
     this.projectBaseDir = options.projectBaseDir || path.resolve();
     this.jasmineCore = options.jasmineCore || require('./jasmineCore');
     this.jasmineCssFiles = this.jasmineCore.files.cssFiles.map(function(
@@ -141,36 +140,26 @@ class Server {
    * @return {Promise<undefined>} A promise that resolves upon successful start.
    */
   start() {
-    const app = this.express();
+    const stack = [];
 
-    app.use('/__jasmine__', this.express.static(this.jasmineCore.files.path));
-    app.use('/__boot__', this.express.static(this.jasmineCore.files.bootDir));
-    app.use(
-      '/__images__',
-      this.express.static(this.jasmineCore.files.imagesDir)
-    );
-    app.use(
-      '/__support__',
-      this.express.static(path.join(__dirname, 'support'))
-    );
-    app.use(
-      '/__spec__',
-      this.express.static(
-        path.resolve(this.projectBaseDir, this.options.specDir)
-      )
-    );
-    app.use(
-      '/__src__',
-      this.express.static(
-        path.resolve(this.projectBaseDir, this.options.srcDir)
-      )
-    );
+    const staticRoutes = {
+      '/__jasmine__': this.jasmineCore.files.path,
+      '/__boot__': this.jasmineCore.files.bootDir,
+      '/__images__': this.jasmineCore.files.imagesDir,
+      '/__support__': path.join(__dirname, 'support'),
+      '/__spec__': path.resolve(this.projectBaseDir, this.options.specDir),
+      '/__src__': path.resolve(this.projectBaseDir, this.options.srcDir),
+    };
+
+    for (const [route, dir] of Object.entries(staticRoutes)) {
+      stack.push(mountAt(route, serveStatic(dir)));
+    }
 
     if (this.options.middleware) {
       for (const [path, middleware] of Object.entries(
         this.options.middleware
       )) {
-        app.use(path, middleware);
+        stack.push(mountAt(path, middleware));
       }
     }
 
@@ -181,7 +170,7 @@ class Server {
             this.options.importMap.moduleRootDir
           )
         : this.projectBaseDir;
-      app.use('/__moduleRoot__', this.express.static(dir));
+      stack.push(mountAt('/__moduleRoot__', serveStatic(dir)));
     }
 
     const indexTemplate = ejs.compile(
@@ -192,35 +181,46 @@ class Server {
     );
 
     const self = this;
-    app.get('/', function(req, res) {
+    stack.push(function(req, res, next) {
+      if (req.method !== 'GET' || parsePath(req.url) !== '/') {
+        return next();
+      }
       try {
-        res.send(
-          indexTemplate({
-            cssFiles: self.allCss(),
-            jasmineJsFiles: self.jasmineJs(),
-            userJsFiles: self.userJs(),
-            esmFilenameExtension: self.options.esmFilenameExtension,
-            importMap: self.importMap(),
-            enableTopLevelAwait: self.options.enableTopLevelAwait || false,
-            modulesWithSideEffectsInSrcFiles:
-              self.options.modulesWithSideEffectsInSrcFiles || false,
-          })
-        );
+        const body = indexTemplate({
+          cssFiles: self.allCss(),
+          jasmineJsFiles: self.jasmineJs(),
+          userJsFiles: self.userJs(),
+          esmFilenameExtension: self.options.esmFilenameExtension,
+          importMap: self.importMap(),
+          enableTopLevelAwait: self.options.enableTopLevelAwait || false,
+          modulesWithSideEffectsInSrcFiles:
+            self.options.modulesWithSideEffectsInSrcFiles || false,
+        });
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(body);
       } catch (error) {
-        res.status(500).send('An error occurred');
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('An error occurred');
         console.error(error);
       }
     });
-    app.get('/__config__/config.js', function(req, res) {
+
+    stack.push(function(req, res, next) {
+      if (
+        req.method !== 'GET' ||
+        parsePath(req.url) !== '/__config__/config.js'
+      ) {
+        return next();
+      }
       try {
-        res.append('Content-type', 'application/javascript');
-        res.send(
-          configTemplate({
-            envConfig: self.options.env || {},
-          })
-        );
+        const body = configTemplate({
+          envConfig: self.options.env || {},
+        });
+        res.writeHead(200, { 'Content-Type': 'application/javascript' });
+        res.end(body);
       } catch (error) {
-        res.status(500).send('An error occurred');
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('An error occurred');
         console.error(error);
       }
     });
@@ -244,6 +244,10 @@ class Server {
       host: listenAddress,
     };
     this._httpHostname = hostname || 'localhost';
+
+    const handler = function(req, res) {
+      runMiddleware(stack, req, res);
+    };
 
     return new Promise(resolve => {
       const callback = () => {
@@ -272,12 +276,12 @@ class Server {
           cert: fs.readFileSync(tlsCert),
         };
         this._httpServer = this._deps.https
-          .createServer(httpsOptions, app)
+          .createServer(httpsOptions, handler)
           .listen(listenOptions, callback);
         this._httpServerScheme = 'https';
       } else {
         this._httpServer = this._deps.http
-          .createServer(app)
+          .createServer(handler)
           .listen(listenOptions, callback);
         this._httpServerScheme = 'http';
       }
@@ -334,6 +338,48 @@ class Server {
   hostname() {
     return this._httpHostname;
   }
+}
+
+function parsePath(url) {
+  const qIndex = url.indexOf('?');
+  return qIndex === -1 ? url : url.slice(0, qIndex);
+}
+
+function mountAt(prefix, middleware) {
+  return function(req, res, next) {
+    if (
+      prefix === '/' ||
+      req.url === prefix ||
+      req.url.startsWith(prefix + '/')
+    ) {
+      const original = req.url;
+      req.url = prefix === '/' ? req.url : req.url.slice(prefix.length) || '/';
+      middleware(req, res, function(err) {
+        req.url = original;
+        next(err);
+      });
+    } else {
+      next();
+    }
+  };
+}
+
+function runMiddleware(stack, req, res) {
+  let i = 0;
+  function next(err) {
+    if (err) {
+      res.writeHead(500);
+      res.end('Internal Server Error');
+      return;
+    }
+    if (i >= stack.length) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    stack[i++](req, res, next);
+  }
+  next();
 }
 
 function isUrl(s) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -140,7 +140,7 @@ class Server {
    * @return {Promise<undefined>} A promise that resolves upon successful start.
    */
   start() {
-    const stack = [];
+    const middlewareStack = [];
 
     const staticRoutes = {
       '/__jasmine__': this.jasmineCore.files.path,
@@ -152,14 +152,14 @@ class Server {
     };
 
     for (const [route, dir] of Object.entries(staticRoutes)) {
-      stack.push(mountAt(route, serveStatic(dir)));
+      middlewareStack.push(mountAt(route, serveStatic(dir)));
     }
 
     if (this.options.middleware) {
       for (const [path, middleware] of Object.entries(
         this.options.middleware
       )) {
-        stack.push(mountAt(path, middleware));
+        middlewareStack.push(mountAt(path, middleware));
       }
     }
 
@@ -170,7 +170,7 @@ class Server {
             this.options.importMap.moduleRootDir
           )
         : this.projectBaseDir;
-      stack.push(mountAt('/__moduleRoot__', serveStatic(dir)));
+      middlewareStack.push(mountAt('/__moduleRoot__', serveStatic(dir)));
     }
 
     const indexTemplate = ejs.compile(
@@ -181,7 +181,7 @@ class Server {
     );
 
     const self = this;
-    stack.push(function(req, res, next) {
+    middlewareStack.push(function(req, res, next) {
       if (req.method !== 'GET' || parsePath(req.url) !== '/') {
         return next();
       }
@@ -205,7 +205,7 @@ class Server {
       }
     });
 
-    stack.push(function(req, res, next) {
+    middlewareStack.push(function(req, res, next) {
       if (
         req.method !== 'GET' ||
         parsePath(req.url) !== '/__config__/config.js'
@@ -245,8 +245,8 @@ class Server {
     };
     this._httpHostname = hostname || 'localhost';
 
-    const handler = function(req, res) {
-      runMiddleware(stack, req, res);
+    const handleRequest = function(req, res) {
+      runMiddlewares(middlewareStack, req, res);
     };
 
     return new Promise(resolve => {
@@ -276,12 +276,12 @@ class Server {
           cert: fs.readFileSync(tlsCert),
         };
         this._httpServer = this._deps.https
-          .createServer(httpsOptions, handler)
+          .createServer(httpsOptions, handleRequest)
           .listen(listenOptions, callback);
         this._httpServerScheme = 'https';
       } else {
         this._httpServer = this._deps.http
-          .createServer(handler)
+          .createServer(handleRequest)
           .listen(listenOptions, callback);
         this._httpServerScheme = 'http';
       }
@@ -364,7 +364,7 @@ function mountAt(prefix, middleware) {
   };
 }
 
-function runMiddleware(stack, req, res) {
+function runMiddlewares(middlewareStack, req, res) {
   let i = 0;
   function next(err) {
     if (err) {
@@ -372,12 +372,12 @@ function runMiddleware(stack, req, res) {
       res.end('Internal Server Error');
       return;
     }
-    if (i >= stack.length) {
+    if (i >= middlewareStack.length) {
       res.writeHead(404);
       res.end('Not found');
       return;
     }
-    stack[i++](req, res, next);
+    middlewareStack[i++](req, res, next);
   }
   next();
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -139,8 +139,9 @@
  * @default true
  */
 /**
- * Import maps entry to generate the `<script type="importmap">` section in the
- * `<head>`, to enable ES Module testing in the browser.
+ * Import maps entry to generate the <code>&lt;script type="importmap"&gt;</code>
+ * section in the <code>&lt;head&gt;</code>, to enable ES Module testing in the
+ * browser.
  *
  * @name Configuration#importMap
  * @type ImportMap | undefined

--- a/lib/types.js
+++ b/lib/types.js
@@ -164,9 +164,10 @@
  * @default false
  */
 /**
- * <p>An optional map from paths to Express application middleware to mount on
- * those paths. This can be used to serve static files, proxy requests to
- * another server, etc.
+ * <p>An optional map from paths to Connect-style middleware to mount on
+ * those paths. Each middleware must be a function with the signature
+ * <code>(req, res, next)</code>. This can be used to serve static files,
+ * proxy requests to another server, etc.
  * <p>Note: Requests made by jasmine-browser-runner (e.g. /, /__jasmine__/*,
  * /__spec__/*, etc) are considered private APIs for semver purposes. If you
  * configure middleware that modifies these requests and responses, there is a
@@ -174,12 +175,12 @@
  * patch releases, may be incompatible with that middleware.
  * @example
  * // jasmine-browser.js
- * const express = require('express');
+ * const serveStatic = require('serve-static');
  *
  * module.exports = {
  *   // ...
  *   middleware: {
- *     '/assets': express.static('./path/to/assets')
+ *     '/assets': serveStatic('./path/to/assets')
  *   }
  * }
  * @name Configuration#middleware

--- a/lib/types.js
+++ b/lib/types.js
@@ -164,11 +164,15 @@
  * @default false
  */
 /**
- * <p>An optional map from paths to Connect-style middleware to mount on
- * those paths. Each middleware must be a function with the signature
- * <code>(req, res, next)</code>. This can be used to serve static files,
- * proxy requests to another server, etc.
- * <p>Note: Requests made by jasmine-browser-runner (e.g. /, /__jasmine__/*,
+ * An optional map from paths to {@link Middleware|Connect-style middleware} to
+ * mount on those paths. This can be used to serve static files, proxy requests
+ * to another server, etc. A middleware mounted at a path receives every request
+ * whose URL is that path or below it, with <code>req.url</code> rewritten
+ * relative to the mount point (so a middleware mounted at <code>/assets</code>
+ * sees <code>/foo.js</code> for a request to <code>/assets/foo.js</code>). A
+ * middleware mounted at <code>/</code> receives every request.
+ *
+ * Note: Requests made by jasmine-browser-runner (e.g. /, /__jasmine__/*,
  * /__spec__/*, etc) are considered private APIs for semver purposes. If you
  * configure middleware that modifies these requests and responses, there is a
  * possibility that future jasmine-browser-runner releases, including minor and
@@ -184,8 +188,26 @@
  *   }
  * }
  * @name Configuration#middleware
- * @type object | undefined
+ * @type {Object.<string, Middleware> | undefined}
  * @default undefined
+ */
+
+/**
+ * A Connect-style middleware function. It either responds to the request by
+ * writing to <code>res</code>, or calls <code>next</code> to pass control to
+ * the next middleware in the stack.
+ * @callback Middleware
+ * @param {http.IncomingMessage} req The incoming request, a Node.js
+ * {@link https://nodejs.org/api/http.html#class-httpincomingmessage|http.IncomingMessage}.
+ * Its <code>url</code> is relative to the path the middleware was mounted on.
+ * @param {http.ServerResponse} res The response, a Node.js
+ * {@link https://nodejs.org/api/http.html#class-httpserverresponse|http.ServerResponse}.
+ * Write to it (e.g. <code>res.writeHead(...)</code> then <code>res.end(...)</code>)
+ * to handle the request.
+ * @param {function(Error=): void} next Passes control to the next middleware.
+ * Call it with no arguments to continue; call it with an <code>Error</code> to
+ * abort the stack and respond with HTTP 500. If no middleware handles the
+ * request, the server responds with HTTP 404.
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "ejs": "^4.0.1",
-        "express": "^5.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "selenium-webdriver": "^4.12.0"
+        "selenium-webdriver": "^4.12.0",
+        "serve-static": "^2.2.0"
       },
       "bin": {
         "jasmine-browser-runner": "bin/jasmine-browser-runner"
@@ -281,19 +281,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -369,30 +356,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -402,44 +365,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -496,46 +421,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -590,20 +475,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -632,36 +503,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escape-html": {
@@ -857,49 +698,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -964,27 +762,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1023,15 +800,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -1039,52 +807,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1166,18 +888,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1186,30 +896,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/http-errors": {
@@ -1226,22 +912,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1297,15 +967,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1328,12 +989,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -1496,36 +1151,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -1586,27 +1211,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1617,15 +1221,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -1742,16 +1337,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1787,19 +1372,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1810,21 +1382,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1832,21 +1389,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/readable-stream": {
@@ -1874,32 +1416,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/selenium-webdriver": {
@@ -2007,78 +1527,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2154,29 +1602,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2192,15 +1617,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2227,12 +1643,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@jasminejs/reporters": "^1.0.0",
     "ejs": "^4.0.1",
-    "express": "^5.0.0",
+    "serve-static": "^2.2.0",
     "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
     "selenium-webdriver": "^4.12.0"
   },

--- a/spec/fixtures/middleware/jasmine-browser.js
+++ b/spec/fixtures/middleware/jasmine-browser.js
@@ -1,4 +1,4 @@
-const express = require('express');
+const serveStatic = require('serve-static');
 
 module.exports = {
   "srcDir": ".",
@@ -10,6 +10,6 @@ module.exports = {
     "name": "headlessChrome"
   },
   "middleware": {
-    "/some-path": express.static('static')
+    "/some-path": serveStatic('static')
   }
 }

--- a/spec/fixtures/middlewareHeaders/aSpec.js
+++ b/spec/fixtures/middlewareHeaders/aSpec.js
@@ -1,0 +1,3 @@
+it('can set custom response headers', function() {
+  expect(window.crossOriginIsolated).toBe(true);
+});

--- a/spec/fixtures/middlewareHeaders/jasmine-browser.js
+++ b/spec/fixtures/middlewareHeaders/jasmine-browser.js
@@ -1,5 +1,3 @@
-const serveStatic = require('serve-static');
-
 module.exports = {
   "srcDir": ".",
   "srcFiles": [],
@@ -10,6 +8,10 @@ module.exports = {
     "name": "headlessChrome"
   },
   "middleware": {
-    "/some-path": serveStatic('static')
+    "/": function(req, res, next) {
+      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+      res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+      next();
+    }
   }
 }

--- a/spec/fixtures/middlewareProxy/aSpec.js
+++ b/spec/fixtures/middlewareProxy/aSpec.js
@@ -1,0 +1,6 @@
+it('can proxy or stub API requests', async function() {
+  const response = await fetch('/api/test');
+  expect(response.ok).toBe(true);
+  const data = await response.json();
+  expect(data).toEqual({ status: "ok" });
+});

--- a/spec/fixtures/middlewareProxy/jasmine-browser.js
+++ b/spec/fixtures/middlewareProxy/jasmine-browser.js
@@ -1,0 +1,28 @@
+const http = require('http');
+
+module.exports = {
+  "srcDir": ".",
+  "srcFiles": [],
+  "specDir": ".",
+  "specFiles": ["aSpec.js"],
+  "helpers": [],
+  "browser": {
+    "name": "headlessChrome"
+  },
+  "middleware": {
+    "/api": function(req, res, next) {
+      const proxyReq = http.request({
+        hostname: 'localhost',
+        port: 18900,
+        path: req.url,
+        method: req.method,
+        headers: req.headers
+      }, function(proxyRes) {
+        res.writeHead(proxyRes.statusCode, proxyRes.headers);
+        proxyRes.pipe(res);
+      });
+      proxyReq.on('error', function(err) { next(err); });
+      req.pipe(proxyReq);
+    }
+  }
+}

--- a/spec/middlewareIntegrationSpec.js
+++ b/spec/middlewareIntegrationSpec.js
@@ -1,8 +1,9 @@
+const http = require('http');
 const { runJasmine, timeoutMs } = require('./integrationSupport');
 
 describe('Middleware integration', function() {
   it(
-    'supports arbitrary Express middleware',
+    'supports serving arbitrary files',
     async function() {
       const { exitCode, stdout, stderr } = await runJasmine(
         'spec/fixtures/middleware',
@@ -13,6 +14,48 @@ describe('Middleware integration', function() {
       jasmine.debugLog('stdout: ' + stdout);
       jasmine.debugLog('stderr: ' + stderr);
       expect(exitCode).toEqual(0);
+    },
+    timeoutMs
+  );
+
+  it(
+    'supports custom response headers',
+    async function() {
+      const { exitCode, stdout, stderr } = await runJasmine(
+        'spec/fixtures/middlewareHeaders',
+        {
+          extraArgs: '--config=jasmine-browser.js',
+        }
+      );
+      jasmine.debugLog('stdout: ' + stdout);
+      jasmine.debugLog('stderr: ' + stderr);
+      expect(exitCode).toEqual(0);
+    },
+    timeoutMs
+  );
+
+  it(
+    'supports proxy-style middleware',
+    async function() {
+      const backend = http.createServer(function(req, res) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+      });
+      await new Promise(resolve => backend.listen(18900, resolve));
+
+      try {
+        const { exitCode, stdout, stderr } = await runJasmine(
+          'spec/fixtures/middlewareProxy',
+          {
+            extraArgs: '--config=jasmine-browser.js',
+          }
+        );
+        jasmine.debugLog('stdout: ' + stdout);
+        jasmine.debugLog('stderr: ' + stderr);
+        expect(exitCode).toEqual(0);
+      } finally {
+        await new Promise(resolve => backend.close(resolve));
+      }
     },
     timeoutMs
   );

--- a/spec/serverSpec.js
+++ b/spec/serverSpec.js
@@ -697,6 +697,23 @@ describe('server', function() {
   describe('middleware', function() {
     beforeEach(function() {
       spyOn(console, 'log');
+
+      this.startServer = async function(middleware) {
+        this.server = new Server({
+          projectBaseDir: path.resolve(__dirname, 'fixtures/importMap'),
+          jasmineCore: this.fakeJasmine,
+          srcDir: 'src',
+          specDir: 'spec',
+          middleware,
+          port: 0,
+        });
+        await this.server.start();
+        return `http://localhost:${this.server.port()}`;
+      };
+    });
+
+    afterEach(async function() {
+      await this.server.stop();
     });
 
     it('uses specified middleware', async function() {
@@ -706,71 +723,71 @@ describe('server', function() {
       function middleware1(req, res, next) {
         middleware1Called = true;
         res.writeHead(200, { 'Content-Type': 'text/plain' });
-        res.end('from middleware1');
+        res.end('middleware1-response');
       }
       function middleware2(req, res, next) {
         middleware2Called = true;
         res.writeHead(200, { 'Content-Type': 'text/plain' });
-        res.end('from middleware2');
+        res.end('middleware2-response');
       }
 
-      const server = new Server({
-        projectBaseDir: path.resolve(__dirname, 'fixtures/importMap'),
-        jasmineCore: this.fakeJasmine,
-        srcDir: 'src',
-        specDir: 'spec',
-        middleware: {
-          '/foo': middleware1,
-          '/bar': middleware2,
-        },
-        port: 0,
+      const baseUrl = await this.startServer({
+        '/foo': middleware1,
+        '/bar': middleware2,
       });
 
-      await server.start();
+      const result1 = await getFile(baseUrl + '/foo');
+      const result2 = await getFile(baseUrl + '/bar');
 
-      try {
-        const baseUrl = `http://localhost:${server.port()}`;
-        const result1 = await getFile(baseUrl + '/foo');
-        const result2 = await getFile(baseUrl + '/bar');
-
-        expect(middleware1Called).toBe(true);
-        expect(middleware2Called).toBe(true);
-        expect(result1).toEqual('from middleware1');
-        expect(result2).toEqual('from middleware2');
-      } finally {
-        await server.stop();
-      }
+      expect(middleware1Called).toBe(true);
+      expect(middleware2Called).toBe(true);
+      expect(result1).toEqual('middleware1-response');
+      expect(result2).toEqual('middleware2-response');
     });
 
     it('runs middleware mounted at / for all requests', async function() {
       const requestUrls = [];
 
-      const server = new Server({
-        projectBaseDir: path.resolve(__dirname, 'fixtures/importMap'),
-        jasmineCore: this.fakeJasmine,
-        srcDir: 'src',
-        specDir: 'spec',
-        middleware: {
-          '/': function(req, res, next) {
-            requestUrls.push(req.url);
-            next();
-          },
+      const baseUrl = await this.startServer({
+        '/': function(req, res, next) {
+          requestUrls.push(req.url);
+          next();
         },
-        port: 0,
       });
 
-      await server.start();
+      await getFile(baseUrl + '/');
+      await getFile(baseUrl + '/__config__/config.js');
 
-      try {
-        const baseUrl = `http://localhost:${server.port()}`;
-        await getFile(baseUrl + '/');
-        await getFile(baseUrl + '/__config__/config.js');
+      expect(requestUrls).toContain('/');
+      expect(requestUrls).toContain('/__config__/config.js');
+    });
 
-        expect(requestUrls).toContain('/');
-        expect(requestUrls).toContain('/__config__/config.js');
-      } finally {
-        await server.stop();
-      }
+    it('responds with 500 when a middleware passes an error to next', async function() {
+      const baseUrl = await this.startServer({
+        '/boom': function(req, res, next) {
+          next(new Error('something went wrong'));
+        },
+      });
+
+      await expectAsync(getFile(baseUrl + '/boom')).toBeRejectedWithError(
+        /status code 500/
+      );
+    });
+
+    it('responds with 404 when no middleware handles the request', async function() {
+      let middlewareCalled = false;
+
+      const baseUrl = await this.startServer({
+        '/': function(req, res, next) {
+          middlewareCalled = true;
+          next();
+        },
+      });
+
+      await expectAsync(getFile(baseUrl + '/missing')).toBeRejectedWithError(
+        /status code 404/
+      );
+      expect(middlewareCalled).toBe(true);
     });
   });
 

--- a/spec/serverSpec.js
+++ b/spec/serverSpec.js
@@ -694,42 +694,84 @@ describe('server', function() {
     });
   });
 
-  it('uses specified Express middleware', async function() {
-    spyOn(console, 'log');
+  describe('middleware', function() {
+    beforeEach(function() {
+      spyOn(console, 'log');
+    });
 
-    const app = jasmine.createSpyObj('app', ['use', 'get', 'listen']);
-    app.listen.and.callFake(function(port, cb) {
-      setImmediate(cb);
-      return {
-        address() {
-          return {};
+    it('uses specified middleware', async function() {
+      let middleware1Called = false;
+      let middleware2Called = false;
+
+      function middleware1(req, res, next) {
+        middleware1Called = true;
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('from middleware1');
+      }
+      function middleware2(req, res, next) {
+        middleware2Called = true;
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('from middleware2');
+      }
+
+      const server = new Server({
+        projectBaseDir: path.resolve(__dirname, 'fixtures/importMap'),
+        jasmineCore: this.fakeJasmine,
+        srcDir: 'src',
+        specDir: 'spec',
+        middleware: {
+          '/foo': middleware1,
+          '/bar': middleware2,
         },
-      };
-    });
-    const fakeExpress = function() {
-      return app;
-    };
-    fakeExpress.static = function() {};
-    function middleware1() {}
-    function middleware2() {}
+        port: 0,
+      });
 
-    const server = new Server({
-      projectBaseDir: path.resolve(__dirname, 'fixtures/importMap'),
-      jasmineCore: this.fakeJasmine,
-      express: fakeExpress,
-      srcDir: 'src',
-      specDir: 'spec',
-      middleware: {
-        '/foo': middleware1,
-        '/bar': middleware2,
-      },
-      port: 0,
+      await server.start();
+
+      try {
+        const baseUrl = `http://localhost:${server.port()}`;
+        const result1 = await getFile(baseUrl + '/foo');
+        const result2 = await getFile(baseUrl + '/bar');
+
+        expect(middleware1Called).toBe(true);
+        expect(middleware2Called).toBe(true);
+        expect(result1).toEqual('from middleware1');
+        expect(result2).toEqual('from middleware2');
+      } finally {
+        await server.stop();
+      }
     });
 
-    await server.start();
+    it('runs middleware mounted at / for all requests', async function() {
+      const requestUrls = [];
 
-    expect(app.use).toHaveBeenCalledWith('/foo', middleware1);
-    expect(app.use).toHaveBeenCalledWith('/bar', middleware2);
+      const server = new Server({
+        projectBaseDir: path.resolve(__dirname, 'fixtures/importMap'),
+        jasmineCore: this.fakeJasmine,
+        srcDir: 'src',
+        specDir: 'spec',
+        middleware: {
+          '/': function(req, res, next) {
+            requestUrls.push(req.url);
+            next();
+          },
+        },
+        port: 0,
+      });
+
+      await server.start();
+
+      try {
+        const baseUrl = `http://localhost:${server.port()}`;
+        await getFile(baseUrl + '/');
+        await getFile(baseUrl + '/__config__/config.js');
+
+        expect(requestUrls).toContain('/');
+        expect(requestUrls).toContain('/__config__/config.js');
+      } finally {
+        await server.stop();
+      }
+    });
   });
 
   describe('When an importMap is provided', function() {


### PR DESCRIPTION
## What

The PR proposes dropping `express` as a runtime dependency and switching to a combination of [`serve-static`](https://github.com/expressjs/serve-static) (the same package Express uses internally) and plain HTTP handlers.

## Why

This dramatically reduces the number of runtime dependencies required for `jasmine-browser-runner`. Switching from `express` to `static-serve` removes 45 transitive runtime dependencies (97 -> 52).

## Notes

This would unfortunately be a breaking change for registering middleware. As such it'd need to be released as a new major version.

Also, thanks for this project ❤️. Big fan of Jasmine since my time at Pivotal in London (2014–2016)

## Motivation

A project I'm working on is looking at switching from a complex Jest + jsdom + Babel setup to using Jasmine & Jasmine Browser Runner. Switching to Jasmine drops our JS dependencies by 173 transitive dependencies. This PR would trim our dependency tree even further.

We want fewer dependencies to reduce our maintenance burden (so many Dependabot PRs) and reduce our surface area for supply chain attacks.

## Appendix

Comparing the output of `npm ls --all --omit dev --parseable` before and after:

```diff
diff --git a/before.txt b/after.txt
index 5ac2156..d7f83db 100644
--- a/before.txt
+++ b/after.txt
@@ -1,98 +1,53 @@
 @jasminejs/reporters
 ejs
-express
 glob
 selenium-webdriver
-jake
-accepts
-body-parser
-content-disposition
-content-type
-cookie-signature
-cookie
-debug
-depd
-encodeurl
-escape-html
-etag
-finalhandler
-fresh
-http-errors
-merge-descriptors
-mime-types
-on-finished
-once
-parseurl
-proxy-addr
-qs
-range-parser
-router
-send
 serve-static
-statuses
-type-is
-vary
+jake
 glob/node_modules/minimatch
 minipass
 path-scurry
 @bazel/runfiles
 jszip
 tmp
 ws
+encodeurl
+escape-html
+parseurl
+send
 async
 filelist
 picocolors
-negotiator
-bytes
-iconv-lite
-raw-body
-ms
-inherits
-setprototypeof
-toidentifier
-mime-db
-ee-first
-wrappy
-forwarded
-ipaddr.js
-side-channel
-is-promise
-path-to-regexp
-media-typer
 glob/node_modules/brace-expansion
 lru-cache
 lie
 pako
 readable-stream
 setimmediate
+debug
+etag
+fresh
+http-errors
+mime-types
+ms
+on-finished
+range-parser
+statuses
 filelist/node_modules/minimatch
-safer-buffer
-unpipe
-es-errors
-object-inspect
-side-channel-list
-side-channel-map
-side-channel-weakmap
 glob/node_modules/balanced-match
 immediate
 core-util-is
+inherits
 isarray
 process-nextick-args
 safe-buffer
 string_decoder
 util-deprecate
+depd
+setprototypeof
+toidentifier
+mime-db
+ee-first
 filelist/node_modules/brace-expansion
-call-bound
-get-intrinsic
 balanced-match
-call-bind-apply-helpers
-es-define-property
-es-object-atoms
-function-bind
-get-proto
-gopd
-has-symbols
-hasown
-math-intrinsics
-dunder-proto
```